### PR TITLE
Aave naive approach

### DIFF
--- a/src/ATokenNaive.sol
+++ b/src/ATokenNaive.sol
@@ -145,6 +145,10 @@ contract ATokenNaive is AToken {
     );
 
     ProposalVote storage _proposalVote = proposalVotes[proposalId];
+    require(
+      _proposalVote.forVotes + _proposalVote.againstVotes + _proposalVote.abstainVotes > 0,
+      "no votes expressed"
+    );
 
     uint256 _proposalSnapshotBlockNumber = governor.proposalSnapshot(proposalId);
 

--- a/src/ATokenNaive.sol
+++ b/src/ATokenNaive.sol
@@ -89,7 +89,7 @@ contract ATokenNaive is AToken {
   /// @notice Method which returns the deadline (as a block number) by which
   /// depositors must express their voting preferences to this Pool contract. It
   /// will always be before the Governor's corresponding proposal deadline. The
-  /// dealine is exclusive, meaning: if this returns (say) block 424242, then the
+  /// deadline is exclusive, meaning: if this returns (say) block 424242, then the
   /// internal voting period will be over on block 424242. The last block for
   /// internal voting will be 424241.
   /// @param proposalId The ID of the proposal in question.

--- a/src/ATokenNaive.sol
+++ b/src/ATokenNaive.sol
@@ -110,10 +110,7 @@ contract ATokenNaive is AToken {
   /// @param proposalId The proposalId in the associated Governor
   /// @param support The depositor's vote preferences in accordance with the `VoteType` enum.
   function expressVote(uint256 proposalId, uint8 support) external {
-    require(
-      !hasCastVotesOnProposal[proposalId],
-      "too late to express, votes already cast"
-    );
+    require(!hasCastVotesOnProposal[proposalId], "too late to express, votes already cast");
     uint256 weight = getPastDeposits(msg.sender, governor.proposalSnapshot(proposalId));
     require(weight > 0, "no weight");
 

--- a/src/ATokenNaive.sol
+++ b/src/ATokenNaive.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.10;
+pragma solidity 0.8.10;
 
 import {AToken} from "aave-v3-core/contracts/protocol/tokenization/AToken.sol";
 import {Errors} from "aave-v3-core/contracts/protocol/libraries/helpers/Errors.sol";
@@ -13,7 +13,7 @@ import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
 interface IFractionalGovernor {
   function token() external returns (address);
-  function proposalSnapshot(uint256 proposalId) external returns (uint256);
+  function proposalSnapshot(uint256 proposalId) external view returns (uint256);
   function proposalDeadline(uint256 proposalId) external view returns (uint256);
   function castVoteWithReasonAndParams(
     uint256 proposalId,
@@ -71,7 +71,7 @@ contract ATokenNaive is AToken {
 
   /// @dev Constructor.
   /// @param _pool The address of the Pool contract
-  /// @param _governor The address of the flex-voting-compatable governance contract.
+  /// @param _governor The address of the flex-voting-compatible governance contract.
   constructor(IPool _pool, address _governor) AToken(_pool) {
     governor = IFractionalGovernor(_governor);
   }
@@ -122,7 +122,7 @@ contract ATokenNaive is AToken {
   }
 
   /// @notice Causes this contract to cast a vote to the Governor for all the
-  /// tokens it currently holds.  Uses the sum of all depositor voting
+  /// tokens it currently holds. Uses the sum of all depositor voting
   /// expressions to decide how to split its voting weight. Can be called by
   /// anyone, but _must_ be called within `CAST_VOTE_WINDOW` blocks before the
   /// proposal deadline.
@@ -274,7 +274,7 @@ contract ATokenNaive is AToken {
   // This was been copied from OZ's ERC20Votes checkpointing system with minor
   // revisions:
   //   * Replace "Vote" with "Deposit", as deposits are what we need to track
-  //   * Make some variable names longer for readibility
+  //   * Make some variable names longer for readability
   //   * Break lines at 80-characters
   struct Checkpoint {
     uint32 fromBlock;

--- a/src/ATokenNaive.sol
+++ b/src/ATokenNaive.sol
@@ -27,7 +27,7 @@ interface IVotingToken {
   function transfer(address to, uint256 amount) external returns (bool);
   function transferFrom(address from, address to, uint256 amount) external returns (bool);
   function delegate(address delegatee) external;
-  function getPastVotes(address account, uint256 blockNumber) external returns (uint256);
+  function getPastVotes(address account, uint256 blockNumber) external view returns (uint256);
 }
 
 contract ATokenNaive is AToken {
@@ -86,7 +86,7 @@ contract ATokenNaive is AToken {
   /// @notice Method which returns the deadline (as a block number) by which
   /// depositors must express their voting preferences to this Pool contract. It
   /// will always be before the Governor's corresponding proposal deadline. The
-  /// dealine is inclusive, meaning: if this returns (say) block 424242, then the
+  /// dealine is exclusive, meaning: if this returns (say) block 424242, then the
   /// internal voting period will be over on block 424242. The last block for
   /// internal voting will be 424241.
   /// @param proposalId The ID of the proposal in question.

--- a/src/ATokenNaive.sol
+++ b/src/ATokenNaive.sol
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10;
+
+import { AToken } from "aave-v3-core/contracts/protocol/tokenization/AToken.sol";
+import { Errors } from 'aave-v3-core/contracts/protocol/libraries/helpers/Errors.sol';
+import { GPv2SafeERC20 } from 'aave-v3-core/contracts/dependencies/gnosis/contracts/GPv2SafeERC20.sol';
+import { IAToken } from 'aave-v3-core/contracts/interfaces/IAToken.sol';
+import { IERC20 } from 'aave-v3-core/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
+import { IPool } from 'aave-v3-core/contracts/interfaces/IPool.sol';
+import { WadRayMath } from 'aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol';
+import { SafeCast } from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+import { Math } from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+
+interface IFractionalGovernor {
+  function token() external returns (address);
+  function proposalSnapshot(uint256 proposalId) external returns (uint256);
+  function proposalDeadline(uint256 proposalId) external view returns (uint256);
+  function castVoteWithReasonAndParams(
+    uint256 proposalId,
+    uint8 support,
+    string calldata reason,
+    bytes memory params
+  ) external returns (uint256);
+}
+
+interface IVotingToken {
+  function transfer(address to, uint256 amount) external returns (bool);
+  function transferFrom(address from, address to, uint256 amount) external returns (bool);
+  function delegate(address delegatee) external;
+  function getPastVotes(address account, uint256 blockNumber) external returns (uint256);
+}
+
+contract ATokenNaive is AToken {
+  using WadRayMath for uint256;
+  using SafeCast for uint256;
+  using GPv2SafeERC20 for IERC20;
+
+  /// @notice The voting options corresponding to those used in the Governor.
+  enum VoteType {
+    Against,
+    For,
+    Abstain
+  }
+
+  /// @notice Data structure to store vote preferences expressed by depositors.
+  struct ProposalVote {
+    uint128 againstVotes;
+    uint128 forVotes;
+    uint128 abstainVotes;
+  }
+
+  /// @notice Must call castVote within this many blocks of the proposal
+  /// deadline, so-as to allow ample time for all depositors to express their
+  /// vote preferences. Corresponds to roughly 4 hours, assuming 12s/block.
+  uint32 constant public CAST_VOTE_WINDOW = 1_200;
+
+  /// @notice Map depositor to deposit amount.
+  mapping (address => uint256) public deposits;
+
+  /// @notice Map borrower to total amount borrowed.
+  mapping (address => uint256) public borrowTotal;
+
+  /// @notice Map proposalId to an address to whether they have voted on this proposal.
+  mapping(uint256 => mapping(address => bool)) private _proposalVotersHasVoted;
+
+  /// @notice Map proposalId to vote totals expressed on this proposal.
+  mapping(uint256 => ProposalVote) public proposalVotes;
+
+  /// @notice The governor contract associated with this governance token.
+  IFractionalGovernor immutable public governor;
+
+  /// @dev Constructor.
+  /// @param _pool The address of the Pool contract
+  /// @param _governor The address of the flex-voting-compatable governance contract.
+  constructor(IPool _pool, address _governor) AToken(_pool) {
+    governor = IFractionalGovernor(_governor);
+  }
+
+  // TODO Is there a better way to do this? It cannot be done in the constructor
+  // because the AToken is just used a proxy -- it won't share an address with
+  // the implementation (i.e. this code).
+  function selfDelegate() public {
+    IVotingToken(governor.token()).delegate(address(this));
+  }
+
+  /// @notice Method which returns the deadline (as a block number) by which
+  /// depositors must express their voting preferences to this Pool contract. It
+  /// will always be before the Governor's corresponding proposal deadline.
+  /// @param proposalId The ID of the proposal in question.
+  function internalVotingPeriodEnd(
+    uint256 proposalId
+  ) public view returns(uint256 _lastVotingBlock) {
+    _lastVotingBlock = governor.proposalDeadline(proposalId) - CAST_VOTE_WINDOW;
+  }
+
+  /// TODO how to handle onBehalfOf?
+  /// TODO should this revert if the vote has been cast?
+  /// @notice Allow a depositor to express their voting preference for a given
+  /// proposal. Their preference is recorded internally but not moved to the
+  /// Governor until `castVote` is called. We deliberately do NOT revert if the
+  /// internalVotingPeriodEnd has passed.
+  /// @param proposalId The proposalId in the associated Governor
+  /// @param support The depositor's vote preferences in accordance with the `VoteType` enum.
+  function expressVote(uint256 proposalId, uint8 support) external {
+    uint256 weight = getPastDeposits(msg.sender, governor.proposalSnapshot(proposalId));
+    if (weight == 0) revert("no weight");
+
+    if (_proposalVotersHasVoted[proposalId][msg.sender]) revert("already voted");
+    _proposalVotersHasVoted[proposalId][msg.sender] = true;
+
+    if (support == uint8(VoteType.Against)) {
+      proposalVotes[proposalId].againstVotes += SafeCast.toUint128(weight);
+    } else if (support == uint8(VoteType.For)) {
+      proposalVotes[proposalId].forVotes += SafeCast.toUint128(weight);
+    } else if (support == uint8(VoteType.Abstain)) {
+      proposalVotes[proposalId].abstainVotes += SafeCast.toUint128(weight);
+    } else {
+      revert("invalid support value, must be included in VoteType enum");
+    }
+  }
+
+  /// @notice Causes this contract to cast a vote to the Governor for all the
+  /// tokens it currently holds.  Uses the sum of all depositor voting
+  /// expressions to decide how to split its voting weight. Can be called by
+  /// anyone, but _must_ be called within `CAST_VOTE_WINDOW` blocks before the
+  /// proposal deadline.
+  /// @param proposalId The ID of the proposal which the Pool will now vote on.
+  function castVote(uint256 proposalId) external {
+    if (internalVotingPeriodEnd(proposalId) > block.number) revert("cannot castVote yet");
+    uint8 unusedSupportParam = uint8(VoteType.Abstain);
+    ProposalVote memory _proposalVote = proposalVotes[proposalId];
+
+    uint256 _proposalSnapshotBlockNumber = governor.proposalSnapshot(proposalId);
+
+    // Use the snapshot of total deposits to determine total voting weight. We cannot
+    // use the proposalVote numbers alone, since some people with deposits at the
+    // snapshot might not have expressed votes.
+    uint256 _totalDepositWeightAtSnapshot = getPastTotalDeposits(_proposalSnapshotBlockNumber);
+
+    // We need 256 bits because of the multiplication we're about to do.
+    uint256 _votingWeightAtSnapshot = IVotingToken(
+      address(_underlyingAsset)
+    ).getPastVotes(address(this), _proposalSnapshotBlockNumber);
+
+    //      forVotesRaw          forVotesScaled
+    // --------------------- = ---------------------
+    //     totalDeposits        deposits (@snapshot)
+    //
+    // forVotesScaled = forVotesRaw * deposits@snapshot / totalDeposits
+    uint128 _forVotesToCast = SafeCast.toUint128(
+      (_votingWeightAtSnapshot * _proposalVote.forVotes) / _totalDepositWeightAtSnapshot
+    );
+    uint128 _againstVotesToCast = SafeCast.toUint128(
+      (_votingWeightAtSnapshot * _proposalVote.againstVotes) / _totalDepositWeightAtSnapshot
+    );
+    uint128 _abstainVotesToCast = SafeCast.toUint128(
+      (_votingWeightAtSnapshot * _proposalVote.abstainVotes) / _totalDepositWeightAtSnapshot
+    );
+
+    bytes memory fractionalizedVotes = abi.encodePacked(
+      _forVotesToCast,
+      _againstVotesToCast,
+      _abstainVotesToCast
+    );
+    governor.castVoteWithReasonAndParams(
+      proposalId,
+      unusedSupportParam,
+      'crowd-sourced vote',
+      fractionalizedVotes
+    );
+  }
+
+  /// Note: this has been modified from Aave v3's AToken to call our custom
+  /// mintScaled function.
+  ///
+  /// @inheritdoc IAToken
+  function mint(
+    address caller,
+    address onBehalfOf,
+    uint256 amount,
+    uint256 index
+  ) external virtual override onlyPool returns (bool) {
+    return __mintScaled(caller, onBehalfOf, amount, index);
+  }
+
+  /// Note: this has been modified from Aave v3's AToken to call our custom
+  /// mintScaled function.
+  ///
+  /// @inheritdoc IAToken
+  function mintToTreasury(uint256 amount, uint256 index) external override onlyPool {
+    if (amount == 0) {
+      return;
+    }
+    __mintScaled(address(POOL), _treasury, amount, index);
+  }
+
+  /// Note: this has been modified from Aave v3's AToken to update deposit
+  /// balance accordingly. We cannot just call `super` here because the function
+  /// is external.
+  ///
+  /// @inheritdoc IAToken
+  function burn(
+    address from,
+    address receiverOfUnderlying,
+    uint256 amount,
+    uint256 index
+  ) external virtual override onlyPool {
+    // Begin modifications.
+    //
+    // We decrement by `amount` instead of any computed/rebased amounts because
+    // `amount` is what actually gets transferred of the underlying asset. We
+    // need our checkpoints to still match up with the underlying asset balance.
+    deposits[from] -= amount;
+    _writeCheckpoint(_checkpoints[from], _subtractionFn, amount);
+    _writeCheckpoint(_totalDepositCheckpoints, _subtractionFn, amount);
+    // End modifications.
+
+    _burnScaled(from, receiverOfUnderlying, amount, index);
+    if (receiverOfUnderlying != address(this)) {
+      IERC20(_underlyingAsset).safeTransfer(receiverOfUnderlying, amount);
+    }
+  }
+
+  /// Note: this has been modified from Aave v3's ScaledBalanceTokenBase
+  /// contract to include balance checkpointing code.
+  /// https://github.com/aave/aave-v3-core/blob/f3e037b3638e3b7c98f0c09c56c5efde54f7c5d2/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol#L61-L91
+  /// Modifications are as indicated below.
+  ///
+  /// @notice Implements the basic logic to mint a scaled balance token.
+  /// @param caller The address performing the mint
+  /// @param onBehalfOf The address of the user that will receive the scaled tokens
+  /// @param amount The amount of tokens getting minted
+  /// @param index The next liquidity index of the reserve
+  /// @return `true` if the the previous balance of the user was 0
+  function __mintScaled(
+    address caller,
+    address onBehalfOf,
+    uint256 amount,
+    uint256 index
+  ) internal returns (bool) {
+    uint256 amountScaled = amount.rayDiv(index);
+    require(amountScaled != 0, Errors.INVALID_MINT_AMOUNT);
+
+    uint256 scaledBalance = super.balanceOf(onBehalfOf);
+    uint256 balanceIncrease = scaledBalance.rayMul(index) -
+      scaledBalance.rayMul(_userState[onBehalfOf].additionalData);
+
+    _userState[onBehalfOf].additionalData = index.toUint128();
+
+    _mint(onBehalfOf, amountScaled.toUint128());
+
+    // Begin modifications.
+    // We increment by `amount` instead of any computed/rebased amounts because
+    // `amount` is what actually gets transferred of the underlying asset. We
+    // need our checkpoints to still match up with the underlying asset balance.
+    deposits[onBehalfOf] += amount;
+    _writeCheckpoint(_checkpoints[onBehalfOf], _additionFn, amount);
+    _writeCheckpoint(_totalDepositCheckpoints, _additionFn, amount);
+    // End modifications.
+
+    uint256 amountToMint = amount + balanceIncrease;
+    emit Transfer(address(0), onBehalfOf, amountToMint);
+    emit Mint(caller, onBehalfOf, amountToMint, balanceIncrease, index);
+
+    return (scaledBalance == 0);
+  }
+
+  //===========================================================================
+  // BEGIN: Checkpointing code.
+  //===========================================================================
+  // This was been copied from OZ's ERC20Votes checkpointing system with minor
+  // revisions:
+  //   * Replace "Vote" with "Deposit", as deposits are what we need to track
+  //   * Make some variable names longer for readibility
+  //   * Break lines at 80-characters
+  struct Checkpoint {
+    uint32 fromBlock;
+    uint224 deposits;
+  }
+  mapping(address => Checkpoint[]) private _checkpoints;
+  Checkpoint[] private _totalDepositCheckpoints;
+  function checkpoints(
+    address account,
+    uint32 pos
+  ) public view virtual returns (Checkpoint memory) {
+    return _checkpoints[account][pos];
+  }
+  function getDeposits(address account) public view virtual returns (uint256) {
+    uint256 pos = _checkpoints[account].length;
+    return pos == 0 ? 0 : _checkpoints[account][pos - 1].deposits;
+  }
+  function getPastDeposits(
+    address account,
+    uint256 blockNumber
+  ) public view virtual returns (uint256) {
+    require(blockNumber < block.number, "block not yet mined");
+    return _checkpointsLookup(_checkpoints[account], blockNumber);
+  }
+  function getPastTotalDeposits(
+    uint256 blockNumber
+  ) public view virtual returns (uint256) {
+    require(blockNumber < block.number, "block not yet mined");
+    return _checkpointsLookup(_totalDepositCheckpoints, blockNumber);
+  }
+  function _checkpointsLookup(
+    Checkpoint[] storage ckpts,
+    uint256 blockNumber
+  ) private view returns (uint256) {
+    // We run a binary search to look for the earliest checkpoint taken after
+    // `blockNumber`.
+    uint256 high = ckpts.length;
+    uint256 low = 0;
+    while (low < high) {
+      uint256 mid = Math.average(low, high);
+      if (ckpts[mid].fromBlock > blockNumber) {
+        high = mid;
+      } else {
+        low = mid + 1;
+      }
+    }
+    return high == 0 ? 0 : ckpts[high - 1].deposits;
+  }
+  function _writeCheckpoint(
+    Checkpoint[] storage ckpts,
+    function(uint256, uint256) view returns (uint256) operation,
+    uint256 delta
+  ) private returns (uint256 oldWeight, uint256 newWeight) {
+    uint256 position = ckpts.length;
+    oldWeight = position == 0 ? 0 : ckpts[position - 1].deposits;
+    newWeight = operation(oldWeight, delta);
+
+    if (position > 0 && ckpts[position - 1].fromBlock == block.number) {
+      ckpts[position - 1].deposits = SafeCast.toUint224(newWeight);
+    } else {
+      ckpts.push(
+        Checkpoint({
+          fromBlock: SafeCast.toUint32(block.number),
+          deposits: SafeCast.toUint224(newWeight)
+        })
+      );
+    }
+  }
+  function _additionFn(uint256 a, uint256 b) private pure returns (uint256) {
+    return a + b;
+  }
+
+  function _subtractionFn(uint256 a, uint256 b) private pure returns (uint256) {
+    return a - b;
+  }
+  //===========================================================================
+  // END: Checkpointing code.
+  //===========================================================================
+}

--- a/test/AaveAtokenFork.t.sol
+++ b/test/AaveAtokenFork.t.sol
@@ -1447,8 +1447,7 @@ contract VoteTest is AaveAtokenForkTest {
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
 
-    (uint256 _againstVotes, uint256 _forVotes, uint256 /* _abstainVotes */) =
-
+    (uint256 _againstVotes, uint256 _forVotes, /*uint256 _abstainVotes */) =
       governor.proposalVotes(_proposalId);
 
     // userA's vote *should* have beaten userB's, but it won't.

--- a/test/AaveAtokenFork.t.sol
+++ b/test/AaveAtokenFork.t.sol
@@ -2,33 +2,56 @@
 pragma solidity >=0.8.10;
 
 // forgefmt: disable-start
-import {Test} from "forge-std/Test.sol";
-import {Vm} from "forge-std/Vm.sol";
-import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import { Test } from "forge-std/Test.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { ERC20 } from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import { IVotes } from "openzeppelin-contracts/contracts/governance/utils/IVotes.sol";
 
-import {IAToken} from "aave-v3-core/contracts/interfaces/IAToken.sol";
-import {AToken} from "aave-v3-core/contracts/protocol/tokenization/AToken.sol";
-import {IPool} from "aave-v3-core/contracts/interfaces/IPool.sol";
-import {ConfiguratorInputTypes} from "aave-v3-core/contracts/protocol/libraries/types/ConfiguratorInputTypes.sol";
-import {PoolConfigurator} from "aave-v3-core/contracts/protocol/pool/PoolConfigurator.sol";
-import {DataTypes} from "aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
-import {AaveOracle} from "aave-v3-core/contracts/misc/AaveOracle.sol";
+import { AaveOracle } from 'aave-v3-core/contracts/misc/AaveOracle.sol';
+import { AToken } from "aave-v3-core/contracts/protocol/tokenization/AToken.sol";
+import { ConfiguratorInputTypes } from 'aave-v3-core/contracts/protocol/libraries/types/ConfiguratorInputTypes.sol';
+import { DataTypes } from 'aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol';
+import { IAToken } from "aave-v3-core/contracts/interfaces/IAToken.sol";
+import { IPool } from 'aave-v3-core/contracts/interfaces/IPool.sol';
+import { PoolConfigurator } from 'aave-v3-core/contracts/protocol/pool/PoolConfigurator.sol';
 
-import {GovToken} from "./GovToken.sol";
+import { ATokenNaive } from "src/ATokenNaive.sol";
+import { FractionalGovernor } from "test/FractionalGovernor.sol";
+import { ProposalReceiverMock } from "test/ProposalReceiverMock.sol";
+import { GovToken } from "test/GovToken.sol";
 
-import {Pool} from "aave-v3-core/contracts/protocol/pool/Pool.sol";
-import "forge-std/console2.sol";
+import { Pool } from 'aave-v3-core/contracts/protocol/pool/Pool.sol'; // Used to etch below.
 // forgefmt: disable-end
 
 contract AaveAtokenForkTest is Test {
   uint256 forkId;
 
-  IAToken aToken;
+  ATokenNaive aToken;
   GovToken govToken;
+  FractionalGovernor governor;
+  ProposalReceiverMock receiver;
   IPool pool;
 
+  // These are addresses on Optimism.
   address dai = 0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1;
   address weth = 0x4200000000000000000000000000000000000006;
+
+  enum ProposalState {
+    Pending,
+    Active,
+    Canceled,
+    Defeated,
+    Succeeded,
+    Queued,
+    Expired,
+    Executed
+  }
+
+  enum VoteType {
+    Against,
+    For,
+    Abstain
+  }
 
   function setUp() public {
     // We need to use optimism for Aave V3 because it's not (yet?) on mainnet.
@@ -37,10 +60,18 @@ contract AaveAtokenForkTest is Test {
     uint256 optimismForkBlock = 26_332_308;
     forkId = vm.createSelectFork(vm.rpcUrl("optimism"), optimismForkBlock);
 
-    // deploy the GOV token
+    // Deploy the GOV token.
     govToken = new GovToken();
-    // Pool address taken from https://dune.com/queries/1329814.
-    pool = IPool(0x794a61358D6845594F94dc1DB02A252b5b4814aD);
+    pool = IPool(0x794a61358D6845594F94dc1DB02A252b5b4814aD); // pool from https://dune.com/queries/1329814
+    vm.label(address(pool), "pool");
+
+    // Deploy the governor.
+    governor = new FractionalGovernor("Governor", IVotes(govToken));
+    vm.label(address(governor), "governor");
+
+    // Deploy the contract which will receive proposal calls.
+    receiver = new ProposalReceiverMock();
+    vm.label(address(receiver), "receiver");
 
     // Uncomment this line to temporarily etch local code onto the fork address
     // so that we can do things like add console.log statements during
@@ -52,7 +83,7 @@ contract AaveAtokenForkTest is Test {
       PoolConfigurator(0x8145eddDf43f50276641b55bd3AD95944510021E);
 
     // deploy the aGOV token
-    AToken _aTokenImplementation = new AToken(pool);
+    AToken _aTokenImplementation = new ATokenNaive(pool, address(governor));
 
     // This is the stableDebtToken implementation that all of the Optimism
     // aTokens use. You can see this here: https://dune.com/queries/1332820.
@@ -114,7 +145,8 @@ contract AaveAtokenForkTest is Test {
         //   address variableDebtToken,
         //   address interestRateStrategyAddress
         // );
-        aToken = AToken(address(uint160(uint256(_event.topics[2]))));
+        aToken = ATokenNaive(address(uint160(uint256(_event.topics[2]))));
+        vm.label(address(aToken), "aToken");
       }
     }
 
@@ -154,13 +186,56 @@ contract AaveAtokenForkTest is Test {
     address _priceOracle = pool.ADDRESSES_PROVIDER().getPriceOracle();
     vm.mockCall(
       _priceOracle,
-      abi.encodeWithSelector(AaveOracle.getAssetPrice.selector, address(govToken)),
+      abi.encodeWithSelector(
+        AaveOracle.getAssetPrice.selector,
+        address(govToken)
+      ),
       // Aave only seems to use USD-based oracles, so we will do the same.
       abi.encode(1e8) // 1 GOV == $1 USD
     );
+
+    // We need to call this selfDelegate function so that the aToken will give
+    // its voting power to itself.
+    aToken.selfDelegate();
   }
 
-  function testFork_SetupCanSupplyGovToAave() public {
+  // ------------------
+  // Helper functions
+  // ------------------
+
+  function _mintGovAndSupplyToAave(address _who, uint256 _govAmount) internal {
+    govToken.exposed_mint(_who, _govAmount);
+    vm.startPrank(_who);
+    govToken.approve(address(pool), type(uint256).max);
+    pool.supply(address(govToken), _govAmount, _who, 0 /* referral code*/);
+    vm.stopPrank();
+  }
+
+  function _createAndSubmitProposal() internal returns(uint256 proposalId) {
+    // Proposal will underflow if we're on the zero block.
+    if (block.number == 0) vm.roll(42);
+
+    // Create a dummy proposal.
+    bytes memory receiverCallData = abi.encodeWithSignature("mockReceiverFunction()");
+    address[] memory targets = new address[](1);
+    uint256[] memory values = new uint256[](1);
+    bytes[] memory calldatas = new bytes[](1);
+    targets[0] = address(receiver);
+    values[0] = 0; // no ETH will be sent
+    calldatas[0] = receiverCallData;
+
+    // Submit the proposal.
+    proposalId = governor.propose(targets, values, calldatas, "A great proposal");
+    assertEq(uint(governor.state(proposalId)), uint(ProposalState.Pending));
+
+    // advance proposal to active state
+    vm.roll(governor.proposalSnapshot(proposalId) + 1);
+    assertEq(uint(governor.state(proposalId)), uint(ProposalState.Active));
+  }
+}
+
+contract Setup is AaveAtokenForkTest {
+  function testFork_SetupATokenDeploy() public {
     assertEq(ERC20(address(aToken)).symbol(), "aOptGOV");
     assertEq(ERC20(address(aToken)).name(), "Aave V3 Optimism GOV");
 
@@ -173,9 +248,21 @@ contract AaveAtokenForkTest is Test {
     //     "slot": "61",
     //     "type": "t_address"
     assertEq(
-      address(uint160(uint256(vm.load(address(aToken), bytes32(uint256(61)))))), address(govToken)
+      address(uint160(uint256(
+        vm.load(address(aToken), bytes32(uint256(61)))
+      ))),
+      address(govToken)
     );
 
+    // The AToken should be delegating to itself.
+    assertEq(
+      govToken.delegates(address(aToken)),
+      address(aToken),
+      "aToken is not delegating to itself"
+    );
+  }
+
+  function testFork_SetupCanSupplyGovToAave() public {
     // Mint GOV and deposit into aave.
     // Confirm that we can supply GOV to the aToken.
     assertEq(aToken.balanceOf(address(this)), 0);
@@ -191,7 +278,11 @@ contract AaveAtokenForkTest is Test {
     assertEq(aToken.balanceOf(address(this)), 2 ether);
 
     // We can withdraw our GOV when we want to.
-    pool.withdraw(address(govToken), 2 ether, address(this));
+    pool.withdraw(
+      address(govToken),
+      2 ether,
+      address(this)
+    );
     assertEq(govToken.balanceOf(address(this)), 42 ether);
     assertEq(aToken.balanceOf(address(this)), 0 ether);
   }
@@ -258,7 +349,10 @@ contract AaveAtokenForkTest is Test {
     address _priceOracle = pool.ADDRESSES_PROVIDER().getPriceOracle();
     vm.mockCall(
       _priceOracle,
-      abi.encodeWithSelector(AaveOracle.getAssetPrice.selector, weth),
+      abi.encodeWithSelector(
+        AaveOracle.getAssetPrice.selector,
+        weth
+      ),
       abi.encode(1) // 1 bip
     );
 
@@ -274,6 +368,1003 @@ contract AaveAtokenForkTest is Test {
     );
     uint256 _bobCurrentAtokenBalance = _awethToken.balanceOf(_bob);
     assertEq(_bobInitAtokenBalance, 0);
-    assertApproxEqRel(_bobCurrentAtokenBalance, _thisATokenBalance, 0.01e18);
+    assertApproxEqRel(
+      _bobCurrentAtokenBalance,
+      _thisATokenBalance,
+      0.01e18
+    );
   }
+}
+
+contract Supply is AaveAtokenForkTest {
+  function test_DepositsAreCheckpointed() public {
+    address _who = address(0xBEEF);
+
+    // TODO randomize?
+    uint256 _amountA = 42 ether;
+    uint256 _amountB = 3 ether;
+
+    // There are no initial deposits.
+    uint256[] memory _checkpoints = new uint256[](3);
+    _checkpoints[0] = block.number;
+
+    // Advance the clock so that checkpoints become meaningful.
+    vm.roll(block.number + 42);
+    vm.warp(block.timestamp + 42 days);
+    _checkpoints[1] = block.number;
+    _mintGovAndSupplyToAave(_who, _amountA);
+
+    // Advance the clock and supply again.
+    vm.roll(block.number + 42);
+    vm.warp(block.timestamp + 42 days);
+    _checkpoints[2] = block.number;
+    _mintGovAndSupplyToAave(_who, _amountB);
+
+    // One more time, so that checkpoint 2 is in the past.
+    vm.roll(block.number + 1);
+
+    // We can still retrieve the user's balance at the given blocks.
+    assertEq(aToken.getPastDeposits(_who, _checkpoints[0]), 0);
+    assertEq(aToken.getPastDeposits(_who, _checkpoints[1]), _amountA);
+    assertEq(aToken.getPastDeposits(_who, _checkpoints[2]), _amountA + _amountB);
+    // TODO why isn't this rebasing?
+    assertEq(aToken.balanceOf(_who), _amountA + _amountB);
+  }
+}
+
+// TODO Why can't I just do `contract Vote is...` here?
+contract VoteTest is AaveAtokenForkTest {
+  function test_UserCanCastAgainstVotes() public {
+    _testUserCanCastVotes(address(0xC0FFEE), 4242 ether, uint8(VoteType.Against));
+  }
+  function test_UserCanCastForVotes() public {
+    _testUserCanCastVotes(address(0xC0FFEE), 4242 ether, uint8(VoteType.For));
+  }
+  function test_UserCanCastAbstainVotes() public {
+    _testUserCanCastVotes(address(0xC0FFEE), 4242 ether, uint8(VoteType.Abstain));
+  }
+  function test_UserCannotExpressAgainstVotesWithoutWeight() public {
+    _testUserCannotExpressVotesWithoutATokens(address(0xBEEF), 0.42 ether, uint8(VoteType.Against));
+  }
+  function test_UserCannotExpressForVotesWithoutWeight() public {
+    _testUserCannotExpressVotesWithoutATokens(address(0xBEEF), 0.42 ether, uint8(VoteType.For));
+  }
+  function test_UserCannotExpressAbstainVotesWithoutWeight() public {
+    _testUserCannotExpressVotesWithoutATokens(address(0xBEEF), 0.42 ether, uint8(VoteType.Abstain));
+  }
+  function test_UserCannotCastAfterVotingPeriodAgainst() public {
+    _testUserCannotCastAfterVotingPeriod(address(0xBABE), 4.2 ether, uint8(VoteType.Against));
+  }
+  function test_UserCannotCastAfterVotingPeriodFor() public {
+    _testUserCannotCastAfterVotingPeriod(address(0xBABE), 4.2 ether, uint8(VoteType.For));
+  }
+  function test_UserCannotCastAfterVotingPeriodAbstain() public {
+    _testUserCannotCastAfterVotingPeriod(address(0xBABE), 4.2 ether, uint8(VoteType.Abstain));
+  }
+  function test_UserCannotDoubleVoteAfterVotingAgainst() public {
+    _tesNoDoubleVoting(address(0xBA5EBA11), 0.042 ether, uint8(VoteType.Against));
+  }
+  function test_UserCannotDoubleVoteAfterVotingFor() public {
+    _tesNoDoubleVoting(address(0xBA5EBA11), 0.042 ether, uint8(VoteType.For));
+  }
+  function test_UserCannotDoubleVoteAfterVotingAbstain() public {
+    _tesNoDoubleVoting(address(0xBA5EBA11), 0.042 ether, uint8(VoteType.Abstain));
+  }
+  function test_UserCannotCastVotesTwiceAfterVotingAgainst() public {
+    _testUserCannotCastVotesTwice(address(0x0DD), 1.42 ether, uint8(VoteType.Against));
+  }
+  function test_UserCannotCastVotesTwiceAfterVotingFor() public {
+    _testUserCannotCastVotesTwice(address(0x0DD), 1.42 ether, uint8(VoteType.For));
+  }
+  function test_UserCannotCastVotesTwiceAfterVotingAbstain() public {
+    _testUserCannotCastVotesTwice(address(0x0DD), 1.42 ether, uint8(VoteType.Abstain));
+  }
+  function test_UserCannotExpressAgainstVotesPriorToDepositing() public {
+    _testUserCannotExpressVotesPriorToDepositing(address(0xC0DE), 4.242 ether, uint8(VoteType.Against));
+  }
+  function test_UserCannotExpressForVotesPriorToDepositing() public {
+    _testUserCannotExpressVotesPriorToDepositing(address(0xC0DE), 4.242 ether, uint8(VoteType.For));
+  }
+  function test_UserCannotExpressAbstainVotesPriorToDepositing() public {
+    _testUserCannotExpressVotesPriorToDepositing(address(0xC0DE), 4.242 ether, uint8(VoteType.Abstain));
+  }
+  function test_UserAgainstVotingWeightIsSnapshotDependent() public {
+    _testUserVotingWeightIsSnapshotDependent(
+      address(0xDAD),
+      0.00042 ether,
+      0.042 ether,
+      uint8(VoteType.Against)
+    );
+  }
+  function test_UserForVotingWeightIsSnapshotDependent() public {
+    _testUserVotingWeightIsSnapshotDependent(
+      address(0xDAD),
+      0.00042 ether,
+      0.042 ether,
+      uint8(VoteType.For)
+    );
+  }
+  function test_UserAbstainVotingWeightIsSnapshotDependent() public {
+    _testUserVotingWeightIsSnapshotDependent(
+      address(0xDAD),
+      0.00042 ether,
+      0.042 ether,
+      uint8(VoteType.Abstain)
+    );
+  }
+  function test_MultipleUsersCanCastVotes() public {
+    _testMultipleUsersCanCastVotes(
+      address(0xD00D),
+      address(0xF00D),
+      0.42424242 ether,
+      0.00000042 ether
+    );
+  }
+  function test_UserCannotMakeThePoolCastVotesImmediatelyAfterVotingAgainst() public {
+    _testUserCannotMakeThePoolCastVotesImmediatelyAfterVoting(
+      address(0xDEAF),
+      0.000001 ether,
+      uint8(VoteType.Against)
+    );
+  }
+  function test_UserCannotMakeThePoolCastVotesImmediatelyAfterVotingFor() public {
+    _testUserCannotMakeThePoolCastVotesImmediatelyAfterVoting(
+      address(0xDEAF),
+      0.000001 ether,
+      uint8(VoteType.For)
+    );
+  }
+  function test_UserCannotMakeThePoolCastVotesImmediatelyAfterVotingAbstain() public {
+    _testUserCannotMakeThePoolCastVotesImmediatelyAfterVoting(
+      address(0xDEAF),
+      0.000001 ether,
+      uint8(VoteType.Abstain)
+    );
+  }
+  function test_VoteWeightIsScaledBasedOnPoolBalanceAgainstFor() public {
+    _testVoteWeightIsScaledBasedOnPoolBalance(
+      VoteWeightIsScaledVars(
+        address(0xFADE),         // voterA
+        address(0xDEED),         // voterB
+        address(0xB0D),          // borrower
+        12 ether,                // voteWeightA
+        4 ether,                 // voteWeightB
+        7 ether,                 // borrowerAssets
+        uint8(VoteType.Against), // supportTypeA
+        uint8(VoteType.For)      // supportTypeB
+      )
+    );
+  }
+  function test_VoteWeightIsScaledBasedOnPoolBalanceAgainstAbstain() public {
+    _testVoteWeightIsScaledBasedOnPoolBalance(
+      VoteWeightIsScaledVars(
+        address(0xFEED),         // voterA
+        address(0xADE),          // voterB
+        address(0xD0E),          // borrower
+        2 ether,                 // voteWeightA
+        7 ether,                 // voteWeightB
+        4 ether,                 // borrowerAssets
+        uint8(VoteType.Against), // supportTypeA
+        uint8(VoteType.Abstain)  // supportTypeB
+      )
+    );
+  }
+  function test_VoteWeightIsScaledBasedOnPoolBalanceForAbstain() public {
+    _testVoteWeightIsScaledBasedOnPoolBalance(
+      VoteWeightIsScaledVars(
+        address(0xED),           // voterA
+        address(0xABE),          // voterB
+        address(0xBED),          // borrower
+        1 ether,                 // voteWeightA
+        1 ether,                 // voteWeightB
+        1 ether,                 // borrowerAssets
+        uint8(VoteType.For),     // supportTypeA
+        uint8(VoteType.Abstain)  // supportTypeB
+      )
+    );
+  }
+  function test_AgainstVotingWeightIsAbandonedIfSomeoneDoesntExpress() public {
+    _testVotingWeightIsAbandonedIfSomeoneDoesntExpress(
+      VotingWeightIsAbandonedVars(
+        address(0x111),         // voterA
+        address(0x222),         // voterB
+        address(0x333),         // borrower
+        1 ether,                // voteWeightA
+        1 ether,                // voteWeightB
+        1 ether,                // borrowerAssets
+        uint8(VoteType.Against) // supportTypeA
+      )
+    );
+  }
+  function test_ForVotingWeightIsAbandonedIfSomeoneDoesntExpress() public {
+    _testVotingWeightIsAbandonedIfSomeoneDoesntExpress(
+      VotingWeightIsAbandonedVars(
+        address(0xAAA),         // voterA
+        address(0xBBB),         // voterB
+        address(0xCCC),         // borrower
+        42 ether,               // voteWeightA
+        24 ether,               // voteWeightB
+        11 ether,               // borrowerAssets
+        uint8(VoteType.For)     // supportTypeA
+      )
+    );
+  }
+  function test_AbstainVotingWeightIsAbandonedIfSomeoneDoesntExpress() public {
+    _testVotingWeightIsAbandonedIfSomeoneDoesntExpress(
+      VotingWeightIsAbandonedVars(
+        address(0x123),         // voterA
+        address(0x456),         // voterB
+        address(0x789),         // borrower
+        24 ether,               // voteWeightA
+        42 ether,               // voteWeightB
+        100 ether,              // borrowerAssets
+        uint8(VoteType.Abstain) // supportTypeA
+      )
+    );
+  }
+  function test_AgainstVotingWeightIsUnaffectedByDepositsAfterProposal() public {
+    _testVotingWeightIsUnaffectedByDepositsAfterProposal(
+      address(0xAAAA),        // voterA
+      address(0xBBBB),        // voterB
+      1 ether,                // voteWeightA
+      2 ether,                // voteWeightB
+      uint8(VoteType.Against) // supportTypeA
+    );
+  }
+  function test_ForVotingWeightIsUnaffectedByDepositsAfterProposal() public {
+    _testVotingWeightIsUnaffectedByDepositsAfterProposal(
+      address(0xCCCC),        // voterA
+      address(0xDDDD),        // voterB
+      0.42 ether,             // voteWeightA
+      0.042 ether,            // voteWeightB
+      uint8(VoteType.For)     // supportTypeA
+    );
+  }
+  function test_AbstainVotingWeightIsUnaffectedByDepositsAfterProposal() public {
+    _testVotingWeightIsUnaffectedByDepositsAfterProposal(
+      address(0xEEEE),        // voterA
+      address(0xFFFF),        // voterB
+      10 ether,               // voteWeightA
+      20 ether,               // voteWeightB
+      uint8(VoteType.Abstain) // supportTypeA
+    );
+  }
+  function test_AgainstVotingWeightDoesNotGoDownWhenUsersBorrow() public {
+    _testVotingWeightDoesNotGoDownWhenUsersBorrow(
+      address(0xC0D),
+      4.242 ether,            // GOV deposit amount
+      1 ether,                // DAI borrow amount
+      uint8(VoteType.Against) // supportType
+    );
+  }
+  function test_ForVotingWeightDoesNotGoDownWhenUsersBorrow() public {
+    _testVotingWeightDoesNotGoDownWhenUsersBorrow(
+      address(0xD0C),
+      424.2 ether,            // GOV deposit amount
+      4 ether,                // DAI borrow amount
+      uint8(VoteType.For)     // supportType
+    );
+  }
+  function test_AbstainVotingWeightDoesNotGoDownWhenUsersBorrow() public {
+    _testVotingWeightDoesNotGoDownWhenUsersBorrow(
+      address(0xCAD),
+      0.4242 ether,           // GOV deposit amount
+      0.0424 ether,           // DAI borrow amount
+      uint8(VoteType.Abstain) // supportType
+    );
+  }
+  function testAgainstVotingWeightGoesDownWhenUsersFullyWithdraw() public {
+    _testVotingWeightGoesDownWhenUsersWithdraw(
+      address(0xC0D3),
+      42 ether,               // supplyAmount
+      type(uint256).max,      // withdrawAmount
+      uint8(VoteType.Against) // supportType
+    );
+  }
+  function testForVotingWeightGoesDownWhenUsersFullyWithdraw() public {
+    _testVotingWeightGoesDownWhenUsersWithdraw(
+      address(0xD0C3),
+      42 ether,               // supplyAmount
+      type(uint256).max,      // withdrawAmount
+      uint8(VoteType.For)     // supportType
+    );
+  }
+  function testAbstainVotingWeightGoesDownWhenUsersFullyWithdraw() public {
+    _testVotingWeightGoesDownWhenUsersWithdraw(
+      address(0xCAD3),
+      42 ether,               // supplyAmount
+      type(uint256).max,      // withdrawAmount
+      uint8(VoteType.Abstain) // supportType
+    );
+  }
+  function testAgainstVotingWeightGoesDownWhenUsersPartiallyWithdraw() public {
+    _testVotingWeightGoesDownWhenUsersWithdraw(
+      address(0xC0D4),
+      42 ether,               // supplyAmount
+      2 ether,                // withdrawAmount
+      uint8(VoteType.Against) // supportType
+    );
+  }
+  function testForVotingWeightGoesDownWhenUsersPartiallyWithdraw() public {
+    _testVotingWeightGoesDownWhenUsersWithdraw(
+      address(0xD0C4),
+      42 ether,               // supplyAmount
+      3 ether,                // withdrawAmount
+      uint8(VoteType.For)     // supportType
+    );
+  }
+  function testAbstainVotingWeightGoesDownWhenUsersPartiallyWithdraw() public {
+    _testVotingWeightGoesDownWhenUsersWithdraw(
+      address(0xCAD4),
+      42 ether,               // supplyAmount
+      10 ether,               // withdrawAmount
+      uint8(VoteType.Abstain) // supportType
+    );
+  }
+
+  function _testUserCanCastVotes(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_who, _voteWeight);
+    assertEq(aToken.balanceOf(_who), _voteWeight, "aToken balance wrong");
+    assertEq(govToken.balanceOf(address(aToken)), _voteWeight, "govToken balance wrong");
+
+    // Advance one block so that our votes will be checkpointed by the govToken;
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+    assertEq(
+      govToken.getPastVotes(address(aToken), block.number - 1),
+      _voteWeight,
+      "getPastVotes returned unexpected result"
+    );
+
+    // _who should now be able to express his/her vote on the proposal.
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+
+    (
+      uint256 _againstVotesExpressed,
+      uint256 _forVotesExpressed,
+      uint256 _abstainVotesExpressed
+    ) = aToken.proposalVotes(_proposalId);
+
+    // Vote preferences have been expressed.
+    assertEq(_forVotesExpressed, _supportType == uint8(VoteType.For) ? _voteWeight : 0);
+    assertEq(_againstVotesExpressed, _supportType == uint8(VoteType.Against) ? _voteWeight : 0);
+    assertEq(_abstainVotesExpressed, _supportType == uint8(VoteType.Abstain) ? _voteWeight : 0);
+
+    (
+      uint256 _againstVotes,
+      uint256 _forVotes,
+      uint256 _abstainVotes
+    ) = governor.proposalVotes(_proposalId);
+
+    // But no actual votes have been cast yet.
+    assertEq(_forVotes, 0);
+    assertEq(_againstVotes, 0);
+    assertEq(_abstainVotes, 0);
+
+    // Wait until after the voting period
+    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+
+    // submit votes on behalf of the pool
+    aToken.castVote(_proposalId);
+
+    // governor should now record votes from the pool
+    (_againstVotes, _forVotes, _abstainVotes) = governor.proposalVotes(_proposalId);
+    assertEq(_forVotes, _forVotesExpressed, "for votes not as expected");
+    assertEq(_againstVotes, _againstVotesExpressed, "against votes not as expected");
+    assertEq(_abstainVotes, _abstainVotesExpressed, "abstain votes not as expected");
+  }
+
+  function _testUserCannotExpressVotesWithoutATokens(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Mint gov but do not deposit
+    govToken.exposed_mint(_who, _voteWeight);
+    vm.prank(_who);
+    govToken.approve(address(pool), type(uint256).max);
+
+    assertEq(govToken.balanceOf(_who), _voteWeight);
+    assertEq(aToken.deposits(_who), 0);
+
+    // Advance one block so that our votes will be checkpointed by the govToken;
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // _who should NOT be able to express his/her vote on the proposal
+    vm.expectRevert(bytes("no weight"));
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, uint8(_supportType));
+  }
+
+  function _testUserCannotCastAfterVotingPeriod(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_who, _voteWeight);
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Express vote preference.
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+
+    // Jump ahead so that we're outside of the proposal's voting period.
+    vm.roll(governor.proposalDeadline(_proposalId) + 1);
+
+    // We should not be able to castVote at this point.
+    vm.expectRevert(bytes("Governor: vote not currently active"));
+    aToken.castVote(_proposalId);
+  }
+
+  function _tesNoDoubleVoting(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_who, _voteWeight);
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // _who should now be able to express his/her vote on the proposal.
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+
+    // Vote early and often.
+    vm.expectRevert(bytes("already voted"));
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+  }
+
+  function _testUserCannotCastVotesTwice(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_who, _voteWeight);
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // _who should now be able to express his/her vote on the proposal.
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+
+    // Wait until after the voting period.
+    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    // Try to submit them again.
+    vm.expectRevert(bytes("GovernorCountingFractional: vote already cast"));
+    aToken.castVote(_proposalId);
+  }
+
+  function _testUserCannotExpressVotesPriorToDepositing(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Create the proposal *before* the user deposits anything.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_who, _voteWeight);
+
+    // Now try to express a voting preference on the proposal.
+    assertEq(aToken.deposits(_who), _voteWeight);
+    vm.expectRevert(bytes("no weight"));
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+  }
+
+  function _testUserVotingWeightIsSnapshotDependent(
+    address _who,
+    uint256 _voteWeightA,
+    uint256 _voteWeightB,
+    uint8 _supportType
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_who, _voteWeightA);
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Sometime later the user deposits some more.
+    vm.roll(governor.proposalDeadline(_proposalId) - 1);
+    _mintGovAndSupplyToAave(_who, _voteWeightB);
+
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+
+    // The internal proposal vote weight should not reflect the new deposit weight.
+    (
+      uint256 _againstVotesExpressed,
+      uint256 _forVotesExpressed,
+      uint256 _abstainVotesExpressed
+    ) = aToken.proposalVotes(_proposalId);
+    assertEq(_forVotesExpressed,     _supportType == uint8(VoteType.For)     ? _voteWeightA : 0);
+    assertEq(_againstVotesExpressed, _supportType == uint8(VoteType.Against) ? _voteWeightA : 0);
+    assertEq(_abstainVotesExpressed, _supportType == uint8(VoteType.Abstain) ? _voteWeightA : 0);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    // Votes cast should likewise reflect only the earlier balance.
+    (uint _againstVotes, uint _forVotes, uint _abstainVotes) = governor.proposalVotes(_proposalId);
+    assertEq(_forVotes,     _supportType == uint8(VoteType.For)     ? _voteWeightA : 0);
+    assertEq(_againstVotes, _supportType == uint8(VoteType.Against) ? _voteWeightA : 0);
+    assertEq(_abstainVotes, _supportType == uint8(VoteType.Abstain) ? _voteWeightA : 0);
+  }
+
+  function _testMultipleUsersCanCastVotes(
+    address _userA,
+    address _userB,
+    uint256 _voteWeightA,
+    uint256 _voteWeightB
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_userA, _voteWeightA);
+    _mintGovAndSupplyToAave(_userB, _voteWeightB);
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Users should now be able to express their votes on the proposal.
+    vm.prank(_userA);
+    aToken.expressVote(_proposalId, uint8(VoteType.Against));
+    vm.prank(_userB);
+    aToken.expressVote(_proposalId, uint8(VoteType.Abstain));
+
+    (
+      uint256 _againstVotesExpressed,
+      uint256 _forVotesExpressed,
+      uint256 _abstainVotesExpressed
+    ) = aToken.proposalVotes(_proposalId);
+    assertEq(_forVotesExpressed, 0);
+    assertEq(_againstVotesExpressed, _voteWeightA);
+    assertEq(_abstainVotesExpressed, _voteWeightB);
+
+    // The governor should have not recieved any votes yet.
+    (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) = governor.proposalVotes(_proposalId);
+    assertEq(_forVotes, 0);
+    assertEq(_againstVotes, 0);
+    assertEq(_abstainVotes, 0);
+
+    // Wait until after the voting period.
+    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    // Governor should now record votes for the pool.
+    (_againstVotes, _forVotes, _abstainVotes) = governor.proposalVotes(_proposalId);
+    assertEq(_forVotes, 0);
+    assertEq(_againstVotes, _voteWeightA);
+    assertEq(_abstainVotes, _voteWeightB);
+  }
+
+  function _testUserCannotMakeThePoolCastVotesImmediatelyAfterVoting(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_who, _voteWeight);
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Express vote.
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+
+    // The AToken's internal voting period has not passed.
+    assert(aToken.internalVotingPeriodEnd(_proposalId) > block.number);
+
+    // Try to submit votes on behalf of the pool.
+    vm.expectRevert(bytes("cannot castVote yet"));
+    aToken.castVote(_proposalId);
+  }
+
+  struct VoteWeightIsScaledVars {
+    address voterA;
+    address voterB;
+    address borrower;
+    uint256 voteWeightA;
+    uint256 voteWeightB;
+    uint256 borrowerAssets;
+    uint8 supportTypeA;
+    uint8 supportTypeB;
+  }
+
+  function _testVoteWeightIsScaledBasedOnPoolBalance(
+    VoteWeightIsScaledVars memory _vars
+  ) private {
+    // This would be a vm.assume if we could do fuzz tests.
+    assertLt(_vars.voteWeightA + _vars.voteWeightB, type(uint128).max);
+
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_vars.voterA, _vars.voteWeightA);
+    _mintGovAndSupplyToAave(_vars.voterB, _vars.voteWeightB);
+    uint256 _initGovBalance = govToken.balanceOf(address(aToken));
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Borrow GOV from the pool, decreasing its token balance.
+    deal(weth, _vars.borrower, _vars.borrowerAssets);
+    vm.startPrank(_vars.borrower);
+    ERC20(weth).approve(address(pool), type(uint256).max);
+    pool.supply(weth, _vars.borrowerAssets, _vars.borrower, 0);
+    // Borrow GOV against WETH
+    pool.borrow(
+      address(govToken),
+      (_vars.voteWeightA + _vars.voteWeightB) / 7, // amount of GOV to borrow
+      uint256(DataTypes.InterestRateMode.STABLE), // interestRateMode
+      0, // referralCode
+      _vars.borrower // onBehalfOf
+    );
+    assertLt(
+      govToken.balanceOf(address(aToken)),
+      _initGovBalance
+    );
+    vm.stopPrank();
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Jump ahead to the proposal snapshot to lock in the pool's balance.
+    vm.roll(governor.proposalSnapshot(_proposalId) + 1);
+    uint256 _expectedVotingWeight = govToken.balanceOf(address(aToken));
+    assert(_expectedVotingWeight < _initGovBalance);
+
+    // A+B express votes
+    vm.prank(_vars.voterA);
+    aToken.expressVote(_proposalId, _vars.supportTypeA);
+    vm.prank(_vars.voterB);
+    aToken.expressVote(_proposalId, _vars.supportTypeB);
+
+    // Wait until after the pool's voting period closes.
+    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    // Vote should be cast as a percentage of the depositer's expressed types, since
+    // the actual weight is different from the deposit weight.
+    (
+      uint256 _againstVotes,
+      uint256 _forVotes,
+      uint256 _abstainVotes
+    ) = governor.proposalVotes(_proposalId);
+
+    // These can differ because votes are rounded.
+    assertApproxEqAbs(
+      _againstVotes + _forVotes + _abstainVotes,
+      _expectedVotingWeight,
+      1
+    );
+
+    if (_vars.supportTypeA == _vars.supportTypeB) {
+      assertEq(_forVotes,     _vars.supportTypeA == uint8(VoteType.For)     ? _expectedVotingWeight : 0);
+      assertEq(_againstVotes, _vars.supportTypeA == uint8(VoteType.Against) ? _expectedVotingWeight : 0);
+      assertEq(_abstainVotes, _vars.supportTypeA == uint8(VoteType.Abstain) ? _expectedVotingWeight : 0);
+    } else {
+      uint256 _expectedVotingWeightA = (_vars.voteWeightA * _expectedVotingWeight) / _initGovBalance;
+      uint256 _expectedVotingWeightB = (_vars.voteWeightB * _expectedVotingWeight) / _initGovBalance;
+
+      // We assert the weight is within a range of 1 because scaled weights are sometimes floored.
+      if (_vars.supportTypeA == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightA, 1);
+      if (_vars.supportTypeB == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightB, 1);
+      if (_vars.supportTypeA == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightA, 1);
+      if (_vars.supportTypeB == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightB, 1);
+      if (_vars.supportTypeA == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightA, 1);
+      if (_vars.supportTypeB == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightB, 1);
+    }
+  }
+
+  struct VotingWeightIsAbandonedVars {
+    address voterA;
+    address voterB;
+    address borrower;
+    uint256 voteWeightA;
+    uint256 voteWeightB;
+    uint256 borrowerAssets;
+    uint8 supportTypeA;
+  }
+
+  function _testVotingWeightIsAbandonedIfSomeoneDoesntExpress(
+    VotingWeightIsAbandonedVars memory _vars
+  ) private {
+    // This would be a vm.assume if we could do fuzz tests.
+    assertLt(_vars.voteWeightA + _vars.voteWeightB, type(uint128).max);
+
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_vars.voterA, _vars.voteWeightA);
+    _mintGovAndSupplyToAave(_vars.voterB, _vars.voteWeightB);
+    uint256 _initGovBalance = govToken.balanceOf(address(aToken));
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Borrow GOV from the pool, decreasing its token balance.
+    deal(weth, _vars.borrower, _vars.borrowerAssets);
+    vm.startPrank(_vars.borrower);
+    ERC20(weth).approve(address(pool), type(uint256).max);
+    pool.supply(weth, _vars.borrowerAssets, _vars.borrower, 0);
+    // Borrow GOV against WETH
+    pool.borrow(
+      address(govToken),
+      (_vars.voteWeightA + _vars.voteWeightB) / 5, // amount of GOV to borrow
+      uint256(DataTypes.InterestRateMode.STABLE), // interestRateMode
+      0, // referralCode
+      _vars.borrower // onBehalfOf
+    );
+    assertLt(
+      govToken.balanceOf(address(aToken)),
+      _initGovBalance
+    );
+    vm.stopPrank();
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Jump ahead to the proposal snapshot to lock in the pool's balance.
+    vm.roll(governor.proposalSnapshot(_proposalId) + 1);
+    uint256 _totalPossibleVotingWeight = govToken.balanceOf(address(aToken));
+
+    uint256 _fullVotingWeight = govToken.balanceOf(address(aToken));
+    assert(_fullVotingWeight < _initGovBalance);
+    uint256 _borrowedGov = govToken.balanceOf(address(_vars.borrower));
+    assertEq(
+      _fullVotingWeight,
+      _vars.voteWeightA + _vars.voteWeightB - _borrowedGov,
+      "voting weight doesn't match calculated value"
+    );
+
+    // Only user A expresses a vote.
+    vm.prank(_vars.voterA);
+    aToken.expressVote(_proposalId, _vars.supportTypeA);
+
+    // Wait until after the pool's voting period closes.
+    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    // Vote should be cast as a percentage of the depositer's expressed types, since
+    // the actual weight is different from the deposit weight.
+    (
+      uint256 _againstVotes,
+      uint256 _forVotes,
+      uint256 _abstainVotes
+    ) = governor.proposalVotes(_proposalId);
+
+    uint256 _expectedVotingWeightA = (_vars.voteWeightA * _fullVotingWeight) / _initGovBalance;
+    uint256 _expectedVotingWeightB = (_vars.voteWeightB * _fullVotingWeight) / _initGovBalance;
+
+    // The pool *could* have voted with this much weight.
+    assertApproxEqAbs(
+      _totalPossibleVotingWeight,
+      _expectedVotingWeightA + _expectedVotingWeightB,
+      1
+    );
+
+    // Actually, though, the pool did not vote with all of the weight it could have.
+    // VoterB's votes were never cast because he/she did not express his/her preference.
+    assertApproxEqAbs(
+      _againstVotes + _forVotes + _abstainVotes, // The total actual weight.
+      _expectedVotingWeightA, // VoterB's weight has been abandoned, only A's is counted.
+      1
+    );
+
+    // We assert the weight is within a range of 1 because scaled weights are sometimes floored.
+    if (_vars.supportTypeA == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightA, 1);
+    if (_vars.supportTypeA == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightA, 1);
+    if (_vars.supportTypeA == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightA, 1);
+  }
+
+  function _testVotingWeightIsUnaffectedByDepositsAfterProposal(
+    address _voterA,
+    address _voterB,
+    uint256 _voteWeightA,
+    uint256 _voteWeightB,
+    uint8 _supportTypeA
+  ) private {
+    // This would be a vm.assume if we could do fuzz tests.
+    assertLt(_voteWeightA + _voteWeightB, type(uint128).max);
+
+    // Mint and deposit for just userA.
+    _mintGovAndSupplyToAave(_voterA, _voteWeightA);
+    uint256 _initGovBalance = govToken.balanceOf(address(aToken));
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Jump ahead to the proposal snapshot to lock in the pool's balance.
+    vm.roll(governor.proposalSnapshot(_proposalId) + 1);
+
+    // Now mint and deposit for userB.
+    _mintGovAndSupplyToAave(_voterB, _voteWeightB);
+
+    uint256 _fullVotingWeight = govToken.balanceOf(address(aToken));
+    assert(_fullVotingWeight > _initGovBalance);
+    assertEq(_fullVotingWeight, _voteWeightA + _voteWeightB);
+
+    // Only user A expresses a vote.
+    vm.prank(_voterA);
+    aToken.expressVote(_proposalId, _supportTypeA);
+
+    // Wait until after the pool's voting period closes.
+    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    (
+      uint256 _againstVotes,
+      uint256 _forVotes,
+      uint256 _abstainVotes
+    ) = governor.proposalVotes(_proposalId);
+
+    if (_supportTypeA == uint8(VoteType.For)) assertEq(_forVotes, _voteWeightA);
+    if (_supportTypeA == uint8(VoteType.Against)) assertEq(_againstVotes, _voteWeightA);
+    if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _voteWeightA);
+  }
+
+  function _testVotingWeightDoesNotGoDownWhenUsersBorrow(
+    address _who,
+    uint256 _voteWeight,
+    uint256 _borrowAmount,
+    uint8 _supportType
+  ) private {
+    // Mint and deposit.
+    _mintGovAndSupplyToAave(_who, _voteWeight);
+
+    // Borrow DAI against GOV position.
+    vm.prank(_who);
+    pool.borrow(
+      dai,
+      _borrowAmount,
+      uint256(DataTypes.InterestRateMode.STABLE), // interestRateMode
+      0, // referralCode
+      _who // onBehalfOf
+    );
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Express voting preference.
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+
+    // Wait until after the pool's voting period closes.
+    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    (
+      uint256 _againstVotes,
+      uint256 _forVotes,
+      uint256 _abstainVotes
+    ) = governor.proposalVotes(_proposalId);
+
+    // Actual voting weight should match the initial deposit.
+    if (_supportType == uint8(VoteType.For)) assertEq(_forVotes, _voteWeight);
+    if (_supportType == uint8(VoteType.Against)) assertEq(_againstVotes, _voteWeight);
+    if (_supportType == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _voteWeight);
+  }
+
+  function _testVotingWeightGoesDownWhenUsersWithdraw(
+    address _who,
+    uint256 _supplyAmount,
+    uint256 _withdrawAmount,
+    uint8 _supportType
+  ) private {
+    // Mint and deposit.
+    _mintGovAndSupplyToAave(_who, _supplyAmount);
+
+    // Immediately withdraw.
+    vm.prank(_who);
+    pool.withdraw(address(govToken), _withdrawAmount, _who);
+    if (_withdrawAmount == type(uint256).max) {
+      assertEq(aToken.balanceOf(_who), 0);
+    } else {
+      assertEq(aToken.balanceOf(_who), _supplyAmount - _withdrawAmount);
+
+      // Have someone else immediately supply the withdrawn amount to make sure
+      // our accounting is handling the change in internal deposit balances.
+      _mintGovAndSupplyToAave(address(this), _withdrawAmount);
+    }
+
+    // Advance one block so that our votes will be checkpointed by the govToken.
+    vm.roll(block.number + 1);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Express a voting preference.
+    if (_withdrawAmount == type(uint256).max) vm.expectRevert(bytes("no weight"));
+    vm.prank(_who);
+    aToken.expressVote(_proposalId, _supportType);
+    if (_withdrawAmount == type(uint256).max) return; // Nothing left to test.
+
+    // Wait until after the pool's voting period closes.
+    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    (
+      uint256 _againstVotes,
+      uint256 _forVotes,
+      uint256 _abstainVotes
+    ) = governor.proposalVotes(_proposalId);
+
+    uint256 _expectedVoteWeight = _supplyAmount - _withdrawAmount;
+    if (_supportType == uint8(VoteType.For)) assertEq(_forVotes, _expectedVoteWeight);
+    if (_supportType == uint8(VoteType.Against)) assertEq(_againstVotes, _expectedVoteWeight);
+    if (_supportType == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _expectedVoteWeight);
+  }
+
+  function _testVotingWeightWorksWithRebasing(
+  ) private {
+  // TODO voting after token balance has rebased
+    // one voter supplies gov
+    // a year passes, his aTokens should now be worth more gov
+    // second voter suppies the same amount of gov
+    // first user should have more voting weight than second user
+  }
+
+  // TODO user cannot express vote after votes have been cast
+  // TODO do we try to handle voting onbehalf of someone else?
 }

--- a/test/AaveAtokenFork.t.sol
+++ b/test/AaveAtokenFork.t.sol
@@ -1421,8 +1421,8 @@ contract VoteTest is AaveAtokenForkTest {
     (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
       governor.proposalVotes(_proposalId);
 
-    // userA's vote should have beaten userB's.
-    assertGt(_forVotes, _againstVotes, "userA did not have more voting power than userB");
+    // userA's vote *should* have beaten userB's, but it won't.
+    assertEq(_forVotes, _againstVotes, "if this fails, you have fixed ATokenNaive!");
   }
 
   // TODO user cannot express vote after votes have been cast

--- a/test/AaveAtokenFork.t.sol
+++ b/test/AaveAtokenFork.t.sol
@@ -1447,7 +1447,7 @@ contract VoteTest is AaveAtokenForkTest {
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
 
-    (uint256 _againstVotes, uint256 _forVotes, /*uint256 _abstainVotes */) =
+    (uint256 _againstVotes, uint256 _forVotes, /*uint256 _abstainVotes */ ) =
       governor.proposalVotes(_proposalId);
 
     // userA's vote *should* have beaten userB's, but it won't.
@@ -1486,10 +1486,7 @@ contract VoteTest is AaveAtokenForkTest {
     aToken.expressVote(_proposalId, _supportType);
   }
 
-  function _testCannotCastVoteWithoutVotesExpressed(
-    address _who,
-    uint8 _supportType
-  ) private {
+  function _testCannotCastVoteWithoutVotesExpressed(address _who, uint8 _supportType) private {
     // Deposit some funds.
     _mintGovAndSupplyToAave(_who, 1 ether);
 

--- a/test/AaveAtokenFork.t.sol
+++ b/test/AaveAtokenFork.t.sol
@@ -1416,7 +1416,8 @@ contract VoteTest is AaveAtokenForkTest {
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
 
-    (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
+    (uint256 _againstVotes, uint256 _forVotes, uint256 /* _abstainVotes */) =
+
       governor.proposalVotes(_proposalId);
 
     // userA's vote *should* have beaten userB's, but it won't.

--- a/test/AaveAtokenFork.t.sol
+++ b/test/AaveAtokenFork.t.sol
@@ -109,7 +109,7 @@ contract AaveAtokenForkTest is Test {
       PoolConfigurator(0x8145eddDf43f50276641b55bd3AD95944510021E);
 
     // deploy the aGOV token
-    AToken _aTokenImplementation = new ATokenNaive(pool, address(governor));
+    AToken _aTokenImplementation = new ATokenNaive(pool, address(governor), 1200);
 
     // This is the stableDebtToken implementation that all of the Optimism
     // aTokens use. You can see this here: https://dune.com/queries/1332820.
@@ -802,7 +802,6 @@ contract VoteTest is AaveAtokenForkTest {
     govToken.approve(address(pool), type(uint256).max);
 
     assertEq(govToken.balanceOf(_who), _voteWeight);
-    assertEq(aToken.deposits(_who), 0);
 
     // Advance one block so that our votes will be checkpointed by the govToken;
     vm.roll(block.number + 1);
@@ -901,7 +900,6 @@ contract VoteTest is AaveAtokenForkTest {
     _mintGovAndSupplyToAave(_who, _voteWeight);
 
     // Now try to express a voting preference on the proposal.
-    assertEq(aToken.deposits(_who), _voteWeight);
     vm.expectRevert(bytes("no weight"));
     vm.prank(_who);
     aToken.expressVote(_proposalId, _supportType);
@@ -1017,7 +1015,7 @@ contract VoteTest is AaveAtokenForkTest {
     assert(aToken.internalVotingPeriodEnd(_proposalId) > block.number);
 
     // Try to submit votes on behalf of the pool.
-    vm.expectRevert(bytes("cannot castVote yet"));
+    vm.expectRevert(bytes("cannot castVote during internal voting period"));
     aToken.castVote(_proposalId);
   }
 

--- a/test/FractionalPool.t.sol
+++ b/test/FractionalPool.t.sol
@@ -122,33 +122,31 @@ contract Deposit is FractionalPoolTest {
   }
 
   function testFuzz_DepositsAreCheckpointed(
-    address _holderA,
-    address _holderB,
+    address _holder,
     uint256 _amountA,
     uint256 _amountB,
     uint24 _depositDelay
   ) public {
     _amountA = bound(_amountA, 1, type(uint128).max);
     _amountB = bound(_amountB, 1, type(uint128).max);
-    vm.assume(_holderA != _holderB);
 
-    _mintGovAndDepositIntoPool(_holderA, _amountA);
-    assertEq(token.balanceOf(_holderA), 0); // they've all been deposited
-    assert(token.balanceOf(address(pool)) > token.balanceOf(_holderA));
+    _mintGovAndDepositIntoPool(_holder, _amountA);
+    assertEq(token.balanceOf(_holder), 0); // they've all been deposited
+    assert(token.balanceOf(address(pool)) > token.balanceOf(_holder));
 
     vm.roll(block.number + 42); // advance so that we can look at checkpoints
 
     // We can still retrieve the user's balance at the given time.
-    assertEq(pool.getPastDeposits(_holderA, block.number - 1), _amountA);
+    assertEq(pool.getPastDeposits(_holder, block.number - 1), _amountA);
 
     uint256 newBlockNum = block.number + _depositDelay;
     vm.roll(newBlockNum);
 
     // Deposit some more.
-    _mintGovAndDepositIntoPool(_holderA, _amountB);
+    _mintGovAndDepositIntoPool(_holder, _amountB);
 
     vm.roll(block.number + 42); // advance so that we can look at checkpoints
-    assertEq(pool.getPastDeposits(_holderA, block.number - 1), _amountA + _amountB);
+    assertEq(pool.getPastDeposits(_holder, block.number - 1), _amountA + _amountB);
   }
 }
 


### PR DESCRIPTION
RE #7 

Rough usecase:

* there is an ERC20, call it GOV
* GOV is the governance token issued by Protocol
* Protocol inherits from [GovernorCountingFractional](https://github.com/ScopeLift/flexible-voting/blob/master/src/GovernorCountingFractional.sol) and thus will accept fractional voting
* I deposit some GOV into Aave and receive aGOV in return
* aGOV implements [FractionalPool](https://github.com/ScopeLift/flexible-voting/blob/master/src/FractionalPool.sol)-like functionality
* as proposals are made to Protocol, I can express my voting preference on them directly to aGOV
* aGOV will then cast fractionally weighted votes to Protocol according to the expressed voting preferences of its holders