### PR TITLE
Atoken miscellaneous cleanup

### DIFF
--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -18,6 +18,28 @@ import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {Checkpoints} from "openzeppelin-contracts/contracts/utils/Checkpoints.sol";
 // forgefmt: disable-end
 
+/// @notice This is an extension of Aave V3's AToken contract which makes it possible for AToken
+/// holders to still vote on governance proposals. This way, holders of governance tokens do not
+/// have to choose between earning yeild on Aave and voting. They can do both.
+///
+/// AToken holders are able to call `expressVote` to signal their preference on open governance
+/// proposals. When they do so, this extention records that preference with weight proportional to
+/// the users's AToken balance at the proposal snapshot.
+///
+/// When the proposal deadline nears, the AToken's public `castVote` function is called to roll up
+/// all internal voting records into a single delegated vote to the Governor contract -- a vote
+/// which specifies the exact For/Abstain/Against totals expressed by AToken holders.
+///
+/// This extension has the following requirements:
+///   (a) the underlying token be a governance token
+///   (b) the related governor contract supports flexible voting (see GovernorCountingFractional)
+///
+/// Participating in governance via AToken voting is completely optional. Users otherwise still
+/// supply, borrow, and hold tokens with Aave as usual.
+///
+/// The original AToken that this contract extends is viewable here:
+///
+///   https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/tokenization/AToken.sol
 contract ATokenFlexVoting is AToken {
   using WadRayMath for uint256;
   using SafeCast for uint256;

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.10;
 
 // forgefmt: disable-start
+import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
+import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 import {AToken} from "aave-v3-core/contracts/protocol/tokenization/AToken.sol";
 import {MintableIncentivizedERC20} from "aave-v3-core/contracts/protocol/tokenization/base/MintableIncentivizedERC20.sol";
 import {Errors} from "aave-v3-core/contracts/protocol/libraries/helpers/Errors.sol";
@@ -15,25 +17,6 @@ import {SafeCast} from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {Checkpoints} from "openzeppelin-contracts/contracts/utils/Checkpoints.sol";
 // forgefmt: disable-end
-
-interface IFractionalGovernor {
-  function token() external returns (address);
-  function proposalSnapshot(uint256 proposalId) external view returns (uint256);
-  function proposalDeadline(uint256 proposalId) external view returns (uint256);
-  function castVoteWithReasonAndParams(
-    uint256 proposalId,
-    uint8 support,
-    string calldata reason,
-    bytes memory params
-  ) external returns (uint256);
-}
-
-interface IVotingToken {
-  function transfer(address to, uint256 amount) external returns (bool);
-  function transferFrom(address from, address to, uint256 amount) external returns (bool);
-  function delegate(address delegatee) external;
-  function getPastVotes(address account, uint256 blockNumber) external view returns (uint256);
-}
 
 contract ATokenFlexVoting is AToken {
   using WadRayMath for uint256;

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -20,10 +20,10 @@ import {Checkpoints} from "openzeppelin-contracts/contracts/utils/Checkpoints.so
 
 /// @notice This is an extension of Aave V3's AToken contract which makes it possible for AToken
 /// holders to still vote on governance proposals. This way, holders of governance tokens do not
-/// have to choose between earning yeild on Aave and voting. They can do both.
+/// have to choose between earning yield on Aave and voting. They can do both.
 ///
 /// AToken holders are able to call `expressVote` to signal their preference on open governance
-/// proposals. When they do so, this extention records that preference with weight proportional to
+/// proposals. When they do so, this extension records that preference with weight proportional to
 /// the users's AToken balance at the proposal snapshot.
 ///
 /// When the proposal deadline nears, the AToken's public `castVote` function is called to roll up

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -2,8 +2,6 @@
 pragma solidity 0.8.10;
 
 // forgefmt: disable-start
-import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
-import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 import {AToken} from "aave-v3-core/contracts/protocol/tokenization/AToken.sol";
 import {MintableIncentivizedERC20} from "aave-v3-core/contracts/protocol/tokenization/base/MintableIncentivizedERC20.sol";
 import {Errors} from "aave-v3-core/contracts/protocol/libraries/helpers/Errors.sol";
@@ -16,6 +14,8 @@ import {WadRayMath} from "aave-v3-core/contracts/protocol/libraries/math/WadRayM
 import {SafeCast} from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {Checkpoints} from "openzeppelin-contracts/contracts/utils/Checkpoints.sol";
+import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
+import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 // forgefmt: disable-end
 
 /// @notice This is an extension of Aave V3's AToken contract which makes it possible for AToken
@@ -39,7 +39,7 @@ import {Checkpoints} from "openzeppelin-contracts/contracts/utils/Checkpoints.so
 ///
 /// The original AToken that this contract extends is viewable here:
 ///
-///   https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/tokenization/AToken.sol
+///   https://github.com/aave/aave-v3-core/blob/c38c627683c0db0449b7c9ea2fbd68bde3f8dc01/contracts/protocol/tokenization/AToken.sol
 contract ATokenFlexVoting is AToken {
   using WadRayMath for uint256;
   using SafeCast for uint256;

--- a/src/FractionalPool.sol
+++ b/src/FractionalPool.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
-import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 import "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
 import "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
+import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 
 ///  @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to
 ///  allow holders of governance tokens to use them in DeFi but still participate in governance. The

--- a/src/FractionalPool.sol
+++ b/src/FractionalPool.sol
@@ -1,26 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.10;
 
+import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
+import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 import "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
 import "openzeppelin-contracts/contracts/utils/math/Math.sol";
-
-interface IFractionalGovernor {
-  function proposalSnapshot(uint256 proposalId) external returns (uint256);
-  function proposalDeadline(uint256 proposalId) external view returns (uint256);
-  function castVoteWithReasonAndParams(
-    uint256 proposalId,
-    uint8 support,
-    string calldata reason,
-    bytes memory params
-  ) external returns (uint256);
-}
-
-interface IVotingToken {
-  function transfer(address to, uint256 amount) external returns (bool);
-  function transferFrom(address from, address to, uint256 amount) external returns (bool);
-  function delegate(address delegatee) external;
-  function getPastVotes(address account, uint256 blockNumber) external returns (uint256);
-}
 
 ///  @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to
 ///  allow holders of governance tokens to use them in DeFi but still participate in governance. The

--- a/src/interfaces/IFractionalGovernor.sol
+++ b/src/interfaces/IFractionalGovernor.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.10;
 
-// @notice The interface that flexible voting-compatbile governors are expected to support.
+/// @dev The interface that flexible voting-compatbile governors are expected to support.
 interface IFractionalGovernor {
   function token() external returns (address);
   function proposalSnapshot(uint256 proposalId) external view returns (uint256);

--- a/src/interfaces/IFractionalGovernor.sol
+++ b/src/interfaces/IFractionalGovernor.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+
+// @notice The interface that flexible voting-compatbile governors are expected to support.
+interface IFractionalGovernor {
+  function token() external returns (address);
+  function proposalSnapshot(uint256 proposalId) external view returns (uint256);
+  function proposalDeadline(uint256 proposalId) external view returns (uint256);
+  function castVoteWithReasonAndParams(
+    uint256 proposalId,
+    uint8 support,
+    string calldata reason,
+    bytes memory params
+  ) external returns (uint256);
+}

--- a/src/interfaces/IVotingToken.sol
+++ b/src/interfaces/IVotingToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.10;
 
-// @notice The interface that flexible voting-compatible voting tokens are expected to support.
+/// @dev The interface that flexible voting-compatible voting tokens are expected to support.
 interface IVotingToken {
   function transfer(address to, uint256 amount) external returns (bool);
   function transferFrom(address from, address to, uint256 amount) external returns (bool);

--- a/src/interfaces/IVotingToken.sol
+++ b/src/interfaces/IVotingToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+
+// @notice The interface that flexible voting-compatible voting tokens are expected to support.
+interface IVotingToken {
+  function transfer(address to, uint256 amount) external returns (bool);
+  function transferFrom(address from, address to, uint256 amount) external returns (bool);
+  function delegate(address delegatee) external;
+  function getPastVotes(address account, uint256 blockNumber) external view returns (uint256);
+}

--- a/test/FractionalPool.t.sol
+++ b/test/FractionalPool.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.10;
 
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";


### PR DESCRIPTION
This PR does the following:
* moves Aave overrides so that the initalizer function is near the constructor
* pulls shared interfaces into their own directory to DRY things up
* adds a high-level description of the ATokenFlexVoting contract