### PR TITLE
Make minor atoken tweaks

### DIFF
--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -8,9 +8,7 @@ import {Errors} from "aave-v3-core/contracts/protocol/libraries/helpers/Errors.s
 import {GPv2SafeERC20} from "aave-v3-core/contracts/dependencies/gnosis/contracts/GPv2SafeERC20.sol";
 import {IAToken} from "aave-v3-core/contracts/interfaces/IAToken.sol";
 import {IAaveIncentivesController} from "aave-v3-core/contracts/interfaces/IAaveIncentivesController.sol";
-import {IERC20} from "aave-v3-core/contracts/dependencies/openzeppelin/contracts/IERC20.sol";
 import {IPool} from "aave-v3-core/contracts/interfaces/IPool.sol";
-import {WadRayMath} from "aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol";
 import {SafeCast} from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {Checkpoints} from "openzeppelin-contracts/contracts/utils/Checkpoints.sol";
@@ -39,11 +37,9 @@ import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 ///
 /// The original AToken that this contract extends is viewable here:
 ///
-///   https://github.com/aave/aave-v3-core/blob/c38c627683c0db0449b7c9ea2fbd68bde3f8dc01/contracts/protocol/tokenization/AToken.sol
+///   https://github.com/aave/aave-v3-core/blob/c38c6276/contracts/protocol/tokenization/AToken.sol
 contract ATokenFlexVoting is AToken {
-  using WadRayMath for uint256;
   using SafeCast for uint256;
-  using GPv2SafeERC20 for IERC20;
   using Checkpoints for Checkpoints.History;
 
   /// @notice The voting options corresponding to those used in the Governor.

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -239,7 +239,7 @@ contract ATokenFlexVoting is AToken {
     // balances at the snapshot might not have expressed votes. We don't want to
     // make it possible for aToken holders to *increase* their voting power when
     // other people don't express their votes. That'd be a terrible incentive.
-    uint256 _totalRawBalanceAtSnapshot = getPastTotalBalances(_proposalSnapshotBlockNumber);
+    uint256 _totalRawBalanceAtSnapshot = getPastTotalBalance(_proposalSnapshotBlockNumber);
 
     // We need 256 bits because of the multiplication we're about to do.
     uint256 _votingWeightAtSnapshot = IVotingToken(address(_underlyingAsset)).getPastVotes(
@@ -295,7 +295,7 @@ contract ATokenFlexVoting is AToken {
 
   /// @notice Returns the total stored balance of all users at _blockNumber.
   /// @param _blockNumber The block at which to lookup the total stored balance.
-  function getPastTotalBalances(uint256 _blockNumber) public view returns (uint256) {
+  function getPastTotalBalance(uint256 _blockNumber) public view returns (uint256) {
     return totalDepositCheckpoints.getAtProbablyRecentBlock(_blockNumber);
   }
 }

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -142,10 +142,10 @@ contract ATokenFlexVoting is AToken {
     totalDepositCheckpoints.push(totalDepositCheckpoints.latest() + amount);
   }
 
-  /// Note: this has been modified from Aave v3's AToken contract to checkpoint raw balances
-  /// accordingly.  Ideally we would have overriden IncentivizedERC20._transfer instead of
-  /// AToken._transfer as we did for _mint and _burn above, but that isn't possible here:
-  /// AToken._transfer *already is* an override of IncentivizedERC20._transfer
+  /// @dev This has been modified from Aave v3's AToken contract to checkpoint raw balances
+  /// accordingly.  Ideally we would have overriden `IncentivizedERC20._transfer` instead of
+  /// `AToken._transfer` as we did for `_mint` and `_burn`, but that isn't possible here:
+  /// `AToken._transfer` *already is* an override of `IncentivizedERC20._transfer`
   ///
   /// @inheritdoc AToken
   function _transfer(

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -10,7 +10,6 @@ import {IAToken} from "aave-v3-core/contracts/interfaces/IAToken.sol";
 import {IAaveIncentivesController} from "aave-v3-core/contracts/interfaces/IAaveIncentivesController.sol";
 import {IPool} from "aave-v3-core/contracts/interfaces/IPool.sol";
 import {SafeCast} from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
-import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {Checkpoints} from "openzeppelin-contracts/contracts/utils/Checkpoints.sol";
 import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -143,8 +143,10 @@ contract ATokenFlexVoting is AToken {
     totalDepositCheckpoints.push(totalDepositCheckpoints.latest() + amount);
   }
 
-  /// Note: this has been modified from Aave v3's AToken contract to
-  /// checkpoint raw balances accordingly.
+  /// Note: this has been modified from Aave v3's AToken contract to checkpoint raw balances
+  /// accordingly.  Ideally we would have overriden IncentivizedERC20._transfer instead of
+  /// AToken._transfer as we did for _mint and _burn above, but that isn't possible here:
+  /// AToken._transfer *already is* an override of IncentivizedERC20._transfer
   ///
   /// @inheritdoc AToken
   function _transfer(

--- a/test/ATokenFlexVotingFork.t.sol
+++ b/test/ATokenFlexVotingFork.t.sol
@@ -1865,13 +1865,13 @@ contract GetPastStoredBalanceTest is AaveAtokenForkTest {
   }
 }
 
-contract GetPastTotalBalancesTest is AaveAtokenForkTest {
-  function test_GetPastTotalBalancesIncreasesOnDeposit() public {
+contract GetPastTotalBalanceTest is AaveAtokenForkTest {
+  function test_GetPastTotalBalanceIncreasesOnDeposit() public {
     _initiateRebasing();
-    assertEq(aToken.getPastTotalBalances(block.number - 1), INITIAL_REBASING_DEPOSIT);
+    assertEq(aToken.getPastTotalBalance(block.number - 1), INITIAL_REBASING_DEPOSIT);
 
-    address _userA = makeAddr("GetPastTotalBalancesIncreasesOnDeposit _userA");
-    address _userB = makeAddr("GetPastTotalBalancesIncreasesOnDeposit _userB");
+    address _userA = makeAddr("GetPastTotalBalanceIncreasesOnDeposit _userA");
+    address _userB = makeAddr("GetPastTotalBalanceIncreasesOnDeposit _userB");
     uint256 _amountA = 4242 ether;
     uint256 _amountB = 123 ether;
 
@@ -1884,10 +1884,10 @@ contract GetPastTotalBalancesTest is AaveAtokenForkTest {
     vm.warp(block.timestamp + 100 days);
 
     // forgefmt: disable-start
-    assertEq(aToken.getPastTotalBalances(block.number - 101), INITIAL_REBASING_DEPOSIT);
-    assertEq(aToken.getPastTotalBalances(block.number - 100), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
-    assertEq(aToken.getPastTotalBalances(block.number - 10), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
-    assertEq(aToken.getPastTotalBalances(block.number - 1), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
+    assertEq(aToken.getPastTotalBalance(block.number - 101), INITIAL_REBASING_DEPOSIT);
+    assertEq(aToken.getPastTotalBalance(block.number - 100), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
+    assertEq(aToken.getPastTotalBalance(block.number - 10), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
+    assertEq(aToken.getPastTotalBalance(block.number - 1), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
     // forgefmt: disable-end
 
     // Another user deposits.
@@ -1899,17 +1899,17 @@ contract GetPastTotalBalancesTest is AaveAtokenForkTest {
     vm.warp(block.timestamp + 100 days);
 
     // forgefmt: disable-start
-    assertEq(aToken.getPastTotalBalances(block.number - 201), INITIAL_REBASING_DEPOSIT);
-    assertEq(aToken.getPastTotalBalances(block.number - 120), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
-    assertEq(aToken.getPastTotalBalances(block.number - 20), INITIAL_REBASING_DEPOSIT + _rawBalanceA + _rawBalanceB);
-    assertEq(aToken.getPastTotalBalances(block.number - 1), INITIAL_REBASING_DEPOSIT + _rawBalanceA + _rawBalanceB);
+    assertEq(aToken.getPastTotalBalance(block.number - 201), INITIAL_REBASING_DEPOSIT);
+    assertEq(aToken.getPastTotalBalance(block.number - 120), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
+    assertEq(aToken.getPastTotalBalance(block.number - 20), INITIAL_REBASING_DEPOSIT + _rawBalanceA + _rawBalanceB);
+    assertEq(aToken.getPastTotalBalance(block.number - 1), INITIAL_REBASING_DEPOSIT + _rawBalanceA + _rawBalanceB);
     // forgefmt: disable-end
   }
 
-  function test_GetPastTotalBalancesDecreasesOnWithdraw() public {
+  function test_GetPastTotalBalanceDecreasesOnWithdraw() public {
     _initiateRebasing();
 
-    address _userA = makeAddr("GetPastTotalBalancesDecreasesOnWithdraw _userA");
+    address _userA = makeAddr("GetPastTotalBalanceDecreasesOnWithdraw _userA");
     uint256 _amountA = 4242 ether;
 
     // Deposit.
@@ -1920,7 +1920,7 @@ contract GetPastTotalBalancesTest is AaveAtokenForkTest {
     vm.roll(block.number + 100);
     vm.warp(block.timestamp + 100 days);
 
-    assertEq(aToken.getPastTotalBalances(block.number - 1), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
+    assertEq(aToken.getPastTotalBalance(block.number - 1), INITIAL_REBASING_DEPOSIT + _rawBalanceA);
 
     vm.startPrank(_userA);
     uint256 _withdrawAmount = aToken.balanceOf(_userA) / 3;
@@ -1932,22 +1932,22 @@ contract GetPastTotalBalancesTest is AaveAtokenForkTest {
     vm.warp(block.timestamp + 100 days);
 
     assertEq(
-      aToken.getPastTotalBalances(block.number - 1),
+      aToken.getPastTotalBalance(block.number - 1),
       INITIAL_REBASING_DEPOSIT + aToken.exposed_RawBalanceOf(_userA)
     );
 
     uint256 _rawBalanceDelta = _rawBalanceA - aToken.exposed_RawBalanceOf(_userA);
     assertEq(
-      aToken.getPastTotalBalances(block.number - 101) - _rawBalanceDelta,
-      aToken.getPastTotalBalances(block.number - 1)
+      aToken.getPastTotalBalance(block.number - 101) - _rawBalanceDelta,
+      aToken.getPastTotalBalance(block.number - 1)
     );
   }
 
-  function test_GetPastTotalBalancesIsUnaffectedByTransfer() public {
+  function test_GetPastTotalBalanceIsUnaffectedByTransfer() public {
     _initiateRebasing();
 
-    address _userA = makeAddr("GetPastTotalBalancesIsUnaffectedByTransfer _userA");
-    address _userB = makeAddr("GetPastTotalBalancesIsUnaffectedByTransfer _userB");
+    address _userA = makeAddr("GetPastTotalBalanceIsUnaffectedByTransfer _userA");
+    address _userB = makeAddr("GetPastTotalBalanceIsUnaffectedByTransfer _userB");
     uint256 _amountA = 4242 ether;
 
     // Deposit.
@@ -1957,7 +1957,7 @@ contract GetPastTotalBalancesTest is AaveAtokenForkTest {
     vm.roll(block.number + 100);
     vm.warp(block.timestamp + 100 days);
 
-    uint256 _totalDeposits = aToken.getPastTotalBalances(block.number - 1);
+    uint256 _totalDeposits = aToken.getPastTotalBalance(block.number - 1);
 
     vm.startPrank(_userA);
     aToken.transfer(_userB, aToken.balanceOf(_userA) / 2);
@@ -1968,7 +1968,7 @@ contract GetPastTotalBalancesTest is AaveAtokenForkTest {
     vm.warp(block.timestamp + 100 days);
 
     assertEq(
-      aToken.getPastTotalBalances(block.number - 1),
+      aToken.getPastTotalBalance(block.number - 1),
       _totalDeposits // No change because of the transfer;
     );
 
@@ -1984,16 +1984,16 @@ contract GetPastTotalBalancesTest is AaveAtokenForkTest {
     vm.warp(block.timestamp + 100 days);
 
     assertEq(
-      aToken.getPastTotalBalances(block.number - 1),
+      aToken.getPastTotalBalance(block.number - 1),
       _totalDeposits // Still no change caused by transfer.
     );
   }
 
-  function test_GetPastTotalBalancesIsUnaffectedByBorrow() public {
+  function test_GetPastTotalBalanceIsUnaffectedByBorrow() public {
     _initiateRebasing();
 
-    address _userA = makeAddr("GetPastTotalBalancesIsUnaffectedByBorrow _userA");
-    uint256 _totalDeposits = aToken.getPastTotalBalances(block.number - 1);
+    address _userA = makeAddr("GetPastTotalBalanceIsUnaffectedByBorrow _userA");
+    uint256 _totalDeposits = aToken.getPastTotalBalance(block.number - 1);
 
     // Borrow gov.
     vm.startPrank(_userA);
@@ -2014,13 +2014,13 @@ contract GetPastTotalBalancesTest is AaveAtokenForkTest {
     vm.roll(block.number + 100);
     vm.warp(block.timestamp + 100 days);
 
-    assertEq(aToken.getPastTotalBalances(block.number - 1), _totalDeposits);
+    assertEq(aToken.getPastTotalBalance(block.number - 1), _totalDeposits);
   }
 
-  function test_GetPastTotalBalancesZerosOutIfAllPositionsAreUnwound() public {
+  function test_GetPastTotalBalanceZerosOutIfAllPositionsAreUnwound() public {
     _initiateRebasing();
 
-    uint256 _totalDeposits = aToken.getPastTotalBalances(block.number - 1);
+    uint256 _totalDeposits = aToken.getPastTotalBalance(block.number - 1);
     assertGt(_totalDeposits, 0);
     assertGt(govToken.balanceOf(address(aToken)), 0);
 
@@ -2048,9 +2048,9 @@ contract GetPastTotalBalancesTest is AaveAtokenForkTest {
     vm.warp(block.timestamp + 1 days);
 
     assertEq(
-      aToken.getPastTotalBalances(block.number - 1),
+      aToken.getPastTotalBalance(block.number - 1),
       0, // Total balances should now be zero; any remaining supply belongs to the reserve.
-      "getPastTotalBalances accounting is wrong"
+      "getPastTotalBalance accounting is wrong"
     );
   }
 }


### PR DESCRIPTION
This PR makes the following small changes to the V3 atoken extension:
* removes two unused libraries
* adds explanation for why we are overriding AToken._transfer
* renames `getPastTotalBalances` (plural) to `getPastTotalBalance` (singular), since there is only one total balance

I noticed these things while I was working on the aave v2 atoken extension.