### PR TITLE
ATokenFlexVoting: Test that borrowers can vote and that votes aren't double counted

### DIFF
--- a/test/ATokenFlexVotingFork.t.sol
+++ b/test/ATokenFlexVotingFork.t.sol
@@ -1261,6 +1261,20 @@ contract CastVote is AaveAtokenForkTest {
       if (_vars.supportTypeB == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightB, 1);
     }
     // forgefmt: disable-end
+
+    // The borrower should also be able to submit votes!
+    vm.prank(_vars.borrower);
+    governor.castVoteWithReasonAndParams(
+      _proposalId,
+      uint8(VoteType.For),
+      "Vote from the person that borrowed Gov from Aave",
+      new bytes(0) // Vote nominally so that all of the borrower's weight is used.
+    );
+
+    // The summed votes should not exceed the amount of Gov initially supplied.
+    (_againstVotes, _forVotes, _abstainVotes) = governor.proposalVotes(_proposalId);
+    assertGe(_initGovBalance, _againstVotes + _forVotes + _abstainVotes);
+    assertGe(_vars.voteWeightA + _vars.voteWeightB, _againstVotes + _forVotes + _abstainVotes);
   }
 
   struct VotingWeightIsAbandonedVars {


### PR DESCRIPTION
We need to make sure that liquidity is taken into consideration when casting votes from aTokens. If some of the governance tokens have been borrowed, this should reduce the amount that the aToken can vote with. We don't want to risk double counting votes!

This was a concern of some folks from Aave, per telegram chat, so I've added some additional test assertions to check for it