### PR TITLE
Support incremental voting on ATokenFlexVoting

### DIFF
--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -192,6 +192,10 @@ contract ATokenFlexVoting is AToken {
   /// @param proposalId The ID of the proposal which the Pool will now vote on.
   function castVote(uint256 proposalId) external {
     ProposalVote storage _proposalVote = proposalVotes[proposalId];
+    require(
+      _proposalVote.forVotes + _proposalVote.againstVotes + _proposalVote.abstainVotes > 0,
+      "no votes expressed"
+    );
     uint256 _proposalSnapshotBlockNumber = GOVERNOR.proposalSnapshot(proposalId);
 
     // Use the snapshot of total raw balances to determine total voting weight.

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -23,7 +23,7 @@ import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 /// proposals. When they do so, this extension records that preference with weight proportional to
 /// the users's AToken balance at the proposal snapshot.
 ///
-/// At any point after voting preferrences have been expressed, the AToken's public `castVote`
+/// At any point after voting preferences have been expressed, the AToken's public `castVote`
 /// function may be called to roll up all internal voting records into a single delegated vote to
 /// the Governor contract -- a vote which specifies the exact For/Abstain/Against totals expressed
 /// by AToken holders. Votes can be rolled up and cast in this manner multiple times for a given
@@ -189,7 +189,7 @@ contract ATokenFlexVoting is AToken {
 
   /// @notice Causes this contract to cast a vote to the Governor for all of the
   /// accumulated votes expressed by users. Uses the sum of all raw (unrebased) balances
-  /// to proportion and split its voting weight. Can be called by anyone. Can be called
+  /// to proportionally split its voting weight. Can be called by anyone. Can be called
   /// multiple times during the lifecycle of a given proposal.
   /// @param proposalId The ID of the proposal which the Pool will now vote on.
   function castVote(uint256 proposalId) external {
@@ -205,7 +205,7 @@ contract ATokenFlexVoting is AToken {
     //   (1) We cannot use the proposalVote numbers alone, since some people with
     //       balances at the snapshot might never express their preferences. If a
     //       large holder never expressed a preference, but this contract nevertheless
-    //       cast votes to the governor with all of its weight, then other users would
+    //       cast votes to the governor with all of its weight, then other users may
     //       effectively have *increased* their voting weight because someone else
     //       didn't participate, which creates all kinds of bad incentives.
     //   (2) Other people might have already expressed their preferences on this

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -55,17 +55,8 @@ contract ATokenFlexVoting is AToken {
     uint128 abstainVotes;
   }
 
-  /// @notice The number of blocks prior to the proposal deadline within which
-  /// `castVote` may be called. Prior to this window, `castVote` will revert so
-  /// as to give users time to call `expressVote` before votes are sent to the
-  /// governor contract.
-  uint32 public immutable CAST_VOTE_WINDOW;
-
   /// @notice Map proposalId to an address to whether they have voted on this proposal.
   mapping(uint256 => mapping(address => bool)) private proposalVotersHasVoted;
-
-  /// @notice Map proposalId to whether or not this contract has cast votes on it.
-  mapping(uint256 => bool) public hasCastVotesOnProposal;
 
   /// @notice Map proposalId to vote totals expressed on this proposal.
   mapping(uint256 => ProposalVote) public proposalVotes;
@@ -83,11 +74,8 @@ contract ATokenFlexVoting is AToken {
   /// @dev Constructor.
   /// @param _pool The address of the Pool contract
   /// @param _governor The address of the flex-voting-compatible governance contract.
-  /// @param _castVoteWindow The number of blocks that users have to express
-  /// their votes on a proposal before votes can be cast.
-  constructor(IPool _pool, address _governor, uint32 _castVoteWindow) AToken(_pool) {
+  constructor(IPool _pool, address _governor) AToken(_pool) {
     GOVERNOR = IFractionalGovernor(_governor);
-    CAST_VOTE_WINDOW = _castVoteWindow;
   }
 
   // forgefmt: disable-start
@@ -174,29 +162,12 @@ contract ATokenFlexVoting is AToken {
     IVotingToken(GOVERNOR.token()).delegate(address(this));
   }
 
-  /// @notice Method which returns the deadline (as a block number) by which
-  /// depositors must express their voting preferences to this Pool contract. It
-  /// will always be before the Governor's corresponding proposal deadline. The
-  /// deadline is exclusive, meaning: if this returns (say) block 424242, then the
-  /// internal voting period will be over on block 424242. The last block for
-  /// internal voting will be 424241.
-  /// @param proposalId The ID of the proposal in question.
-  function internalVotingPeriodEnd(uint256 proposalId)
-    public
-    view
-    returns (uint256 _lastVotingBlock)
-  {
-    _lastVotingBlock = GOVERNOR.proposalDeadline(proposalId) - CAST_VOTE_WINDOW;
-  }
-
   /// @notice Allow a depositor to express their voting preference for a given
   /// proposal. Their preference is recorded internally but not moved to the
-  /// Governor until `castVote` is called. We deliberately do NOT revert if the
-  /// internalVotingPeriodEnd has passed.
+  /// Governor until `castVote` is called.
   /// @param proposalId The proposalId in the associated Governor
   /// @param support The depositor's vote preferences in accordance with the `VoteType` enum.
   function expressVote(uint256 proposalId, uint8 support) external {
-    require(!hasCastVotesOnProposal[proposalId], "too late to express, votes already cast");
     uint256 weight = getPastStoredBalance(msg.sender, GOVERNOR.proposalSnapshot(proposalId));
     require(weight > 0, "no weight");
 
@@ -214,25 +185,13 @@ contract ATokenFlexVoting is AToken {
     }
   }
 
-  /// @notice Causes this contract to cast a vote to the Governor for all the
-  /// tokens it currently holds. Uses the sum of all depositor voting
+  /// @notice Causes this contract to cast a vote to the Governor for all of the
+  /// accumulated votes expressed by users. Uses the sum of all depositor voting
   /// expressions to decide how to split its voting weight. Can be called by
-  /// anyone, but _must_ be called within `CAST_VOTE_WINDOW` blocks before the
-  /// proposal deadline. We don't bother to check if the vote has already been
-  /// cast -- GovernorCountingFractional will revert if it has.
+  /// anyone.
   /// @param proposalId The ID of the proposal which the Pool will now vote on.
   function castVote(uint256 proposalId) external {
-    require(
-      internalVotingPeriodEnd(proposalId) <= block.number,
-      "cannot castVote during internal voting period"
-    );
-
     ProposalVote storage _proposalVote = proposalVotes[proposalId];
-    require(
-      _proposalVote.forVotes + _proposalVote.againstVotes + _proposalVote.abstainVotes > 0,
-      "no votes expressed"
-    );
-
     uint256 _proposalSnapshotBlockNumber = GOVERNOR.proposalSnapshot(proposalId);
 
     // Use the snapshot of total raw balances to determine total voting weight.
@@ -266,7 +225,9 @@ contract ATokenFlexVoting is AToken {
     // weights. It makes no difference what vote type this is.
     uint8 unusedSupportParam = uint8(VoteType.Abstain);
 
-    hasCastVotesOnProposal[proposalId] = true;
+    // Clear the stored votes so that we don't double-cast them.
+    delete proposalVotes[proposalId];
+
     bytes memory fractionalizedVotes =
       abi.encodePacked(_forVotesToCast, _againstVotesToCast, _abstainVotesToCast);
     GOVERNOR.castVoteWithReasonAndParams(

--- a/test/ATokenFlexVotingFork.t.sol
+++ b/test/ATokenFlexVotingFork.t.sol
@@ -1616,6 +1616,11 @@ contract CastVote is AaveAtokenForkTest {
     if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weightA);
     if (_supportTypeA != uint8(VoteType.Abstain)) assertEq(_abstainVotes, 0);
 
+    // UserA should not be able to express votes again.
+    vm.prank(_userA);
+    vm.expectRevert("already voted");
+    aToken.expressVote(_proposalId, _supportTypeA);
+
     // UserB expresses a voting preference on the proposal.
     vm.prank(_userB);
     aToken.expressVote(_proposalId, _supportTypeB);

--- a/test/ATokenFlexVotingFork.t.sol
+++ b/test/ATokenFlexVotingFork.t.sol
@@ -1675,11 +1675,12 @@ contract CastVote is AaveAtokenForkTest {
     uint8 _supportTypeB
   ) private {
     require(_supportTypeA != _supportTypeB, "This test assumes the support types are different");
-    uint256 _weight = 1 ether;
+    uint256 _weightA = 1 ether;
+    uint256 _weightB = 3 ether;
 
     // Deposit some funds.
-    _mintGovAndSupplyToAave(_userA, _weight);
-    _mintGovAndSupplyToAave(_userB, _weight);
+    _mintGovAndSupplyToAave(_userA, _weightA);
+    _mintGovAndSupplyToAave(_userB, _weightB);
 
     // Create the proposal.
     uint256 _proposalId = _createAndSubmitProposal();
@@ -1694,11 +1695,11 @@ contract CastVote is AaveAtokenForkTest {
     (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
       governor.proposalVotes(_proposalId);
 
-    if (_supportTypeA == uint8(VoteType.For)) assertEq(_forVotes, _weight);
+    if (_supportTypeA == uint8(VoteType.For)) assertEq(_forVotes, _weightA);
     if (_supportTypeA != uint8(VoteType.For)) assertEq(_forVotes, 0);
-    if (_supportTypeA == uint8(VoteType.Against)) assertEq(_againstVotes, _weight);
+    if (_supportTypeA == uint8(VoteType.Against)) assertEq(_againstVotes, _weightA);
     if (_supportTypeA != uint8(VoteType.Against)) assertEq(_againstVotes, 0);
-    if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weight);
+    if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weightA);
     if (_supportTypeA != uint8(VoteType.Abstain)) assertEq(_abstainVotes, 0);
 
     // UserB expresses a voting preference on the proposal.
@@ -1710,9 +1711,12 @@ contract CastVote is AaveAtokenForkTest {
 
     (_againstVotes, _forVotes, _abstainVotes) = governor.proposalVotes(_proposalId);
 
-    if (_supportTypeB == uint8(VoteType.For)) assertEq(_forVotes, _weight);
-    if (_supportTypeB == uint8(VoteType.Against)) assertEq(_againstVotes, _weight);
-    if (_supportTypeB == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weight);
+    if (_supportTypeA == uint8(VoteType.For)) assertEq(_forVotes, _weightA);
+    if (_supportTypeA == uint8(VoteType.Against)) assertEq(_againstVotes, _weightA);
+    if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weightA);
+    if (_supportTypeB == uint8(VoteType.For)) assertEq(_forVotes, _weightB);
+    if (_supportTypeB == uint8(VoteType.Against)) assertEq(_againstVotes, _weightB);
+    if (_supportTypeB == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weightB);
   }
 }
 

--- a/test/ATokenFlexVotingFork.t.sol
+++ b/test/ATokenFlexVotingFork.t.sol
@@ -818,12 +818,30 @@ contract CastVote is AaveAtokenForkTest {
     );
   }
 
-  function test_VotesCanBeCastIncrementally() public {
+  function test_VotesCanBeCastIncrementally1() public {
     _testVotesCanBeCastIncrementally(
       makeAddr("test_VotesCanBeCastIncrementally userA #1"),
       makeAddr("test_VotesCanBeCastIncrementally userB #1"),
       uint8(VoteType.For), // supportTypeA
       uint8(VoteType.Abstain) // supportTypeB
+    );
+  }
+
+  function test_VotesCanBeCastIncrementally2() public {
+    _testVotesCanBeCastIncrementally(
+      makeAddr("test_VotesCanBeCastIncrementally userA #2"),
+      makeAddr("test_VotesCanBeCastIncrementally userB #2"),
+      uint8(VoteType.For), // supportTypeA
+      uint8(VoteType.For) // supportTypeB
+    );
+  }
+
+  function test_VotesCanBeCastIncrementally3() public {
+    _testVotesCanBeCastIncrementally(
+      makeAddr("test_VotesCanBeCastIncrementally userA #3"),
+      makeAddr("test_VotesCanBeCastIncrementally userB #3"),
+      uint8(VoteType.Against), // supportTypeA
+      uint8(VoteType.For) // supportTypeB
     );
   }
 
@@ -1582,13 +1600,13 @@ contract CastVote is AaveAtokenForkTest {
     }
   }
 
+  // TODO this should really just be a fuzz test.
   function _testVotesCanBeCastIncrementally(
     address _userA,
     address _userB,
     uint8 _supportTypeA,
     uint8 _supportTypeB
   ) private {
-    require(_supportTypeA != _supportTypeB, "This test assumes the support types are different");
     uint256 _weightA = 1 ether;
     uint256 _weightB = 3 ether;
 
@@ -1609,12 +1627,17 @@ contract CastVote is AaveAtokenForkTest {
     (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
       governor.proposalVotes(_proposalId);
 
-    if (_supportTypeA == uint8(VoteType.For)) assertEq(_forVotes, _weightA);
-    if (_supportTypeA != uint8(VoteType.For)) assertEq(_forVotes, 0);
-    if (_supportTypeA == uint8(VoteType.Against)) assertEq(_againstVotes, _weightA);
-    if (_supportTypeA != uint8(VoteType.Against)) assertEq(_againstVotes, 0);
-    if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weightA);
-    if (_supportTypeA != uint8(VoteType.Abstain)) assertEq(_abstainVotes, 0);
+    uint256 _expectedForVotes;
+    uint256 _expectedAgainstVotes;
+    uint256 _expectedAbstainVotes;
+
+    if (_supportTypeA == uint256(VoteType.For)) _expectedForVotes += _weightA;
+    if (_supportTypeA == uint256(VoteType.Against)) _expectedAgainstVotes += _weightA;
+    if (_supportTypeA == uint256(VoteType.Abstain)) _expectedAbstainVotes += _weightA;
+
+    assertEq(_forVotes, _expectedForVotes);
+    assertEq(_againstVotes, _expectedAgainstVotes);
+    assertEq(_abstainVotes, _expectedAbstainVotes);
 
     // UserA should not be able to express votes again.
     vm.prank(_userA);
@@ -1630,12 +1653,13 @@ contract CastVote is AaveAtokenForkTest {
 
     (_againstVotes, _forVotes, _abstainVotes) = governor.proposalVotes(_proposalId);
 
-    if (_supportTypeA == uint8(VoteType.For)) assertEq(_forVotes, _weightA);
-    if (_supportTypeA == uint8(VoteType.Against)) assertEq(_againstVotes, _weightA);
-    if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weightA);
-    if (_supportTypeB == uint8(VoteType.For)) assertEq(_forVotes, _weightB);
-    if (_supportTypeB == uint8(VoteType.Against)) assertEq(_againstVotes, _weightB);
-    if (_supportTypeB == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weightB);
+    if (_supportTypeB == uint256(VoteType.For)) _expectedForVotes += _weightB;
+    if (_supportTypeB == uint256(VoteType.Against)) _expectedAgainstVotes += _weightB;
+    if (_supportTypeB == uint256(VoteType.Abstain)) _expectedAbstainVotes += _weightB;
+
+    assertEq(_forVotes, _expectedForVotes);
+    assertEq(_againstVotes, _expectedAgainstVotes);
+    assertEq(_abstainVotes, _expectedAbstainVotes);
   }
 }
 

--- a/test/ATokenFlexVotingFork.t.sol
+++ b/test/ATokenFlexVotingFork.t.sol
@@ -114,7 +114,7 @@ contract AaveAtokenForkTest is Test {
       PoolConfigurator(0x8145eddDf43f50276641b55bd3AD95944510021E);
 
     // deploy the aGOV token
-    AToken _aTokenImplementation = new MockATokenFlexVoting(pool, address(governor), 1200);
+    AToken _aTokenImplementation = new MockATokenFlexVoting(pool, address(governor));
 
     // This is the stableDebtToken implementation that all of the Optimism
     // aTokens use. You can see this here: https://dune.com/queries/1332820.
@@ -866,6 +866,15 @@ contract CastVote is AaveAtokenForkTest {
     );
   }
 
+  function test_VotesCanBeCastIncrementally() public {
+    _testVotesCanBeCastIncrementally(
+      makeAddr("test_VotesCanBeCastIncrementally userA #1"),
+      makeAddr("test_VotesCanBeCastIncrementally userB #1"),
+      uint8(VoteType.For), // supportTypeA
+      uint8(VoteType.Abstain) // supportTypeB
+    );
+  }
+
   function test_CastAbstainVoteWithFullyTransferredATokens() public {
     _testCastVoteWithTransferredATokens(
       makeAddr("CastVoteWithTransferredATokens userA #3"),
@@ -960,7 +969,7 @@ contract CastVote is AaveAtokenForkTest {
     assertEq(_abstainVotes, 0);
 
     // Wait until after the voting period
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // submit votes on behalf of the pool
     aToken.castVote(_proposalId);
@@ -1047,7 +1056,7 @@ contract CastVote is AaveAtokenForkTest {
     aToken.expressVote(_proposalId, _supportType);
 
     // Wait until after the voting period.
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
@@ -1144,7 +1153,7 @@ contract CastVote is AaveAtokenForkTest {
     assertEq(_abstainVotes, 0);
 
     // Wait until after the voting period.
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
@@ -1171,11 +1180,9 @@ contract CastVote is AaveAtokenForkTest {
     vm.prank(_who);
     aToken.expressVote(_proposalId, _supportType);
 
-    // The AToken's internal voting period has not passed.
-    assert(aToken.internalVotingPeriodEnd(_proposalId) > block.number);
-
     // Try to submit votes on behalf of the pool.
-    vm.expectRevert(bytes("cannot castVote during internal voting period"));
+    // TODO this is fine now
+    // vm.expectRevert(bytes("cannot castVote during internal voting period"));
     aToken.castVote(_proposalId);
   }
 
@@ -1231,7 +1238,7 @@ contract CastVote is AaveAtokenForkTest {
     aToken.expressVote(_proposalId, _vars.supportTypeB);
 
     // Wait until after the pool's voting period closes.
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
@@ -1344,7 +1351,7 @@ contract CastVote is AaveAtokenForkTest {
     aToken.expressVote(_proposalId, _vars.supportTypeA);
 
     // Wait until after the pool's voting period closes.
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
@@ -1410,7 +1417,7 @@ contract CastVote is AaveAtokenForkTest {
     aToken.expressVote(_proposalId, _supportTypeA);
 
     // Wait until after the pool's voting period closes.
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
@@ -1450,7 +1457,7 @@ contract CastVote is AaveAtokenForkTest {
     aToken.expressVote(_proposalId, _supportType);
 
     // Wait until after the pool's voting period closes.
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
@@ -1496,7 +1503,7 @@ contract CastVote is AaveAtokenForkTest {
     if (_withdrawAmount == type(uint256).max) return; // Nothing left to test.
 
     // Wait until after the pool's voting period closes.
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
@@ -1542,7 +1549,7 @@ contract CastVote is AaveAtokenForkTest {
     aToken.expressVote(_proposalId, uint8(VoteType.Against));
 
     // Wait until after the pool's voting period closes.
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
@@ -1571,14 +1578,15 @@ contract CastVote is AaveAtokenForkTest {
     aToken.expressVote(_proposalId, _supportType);
 
     // Wait until after the voting period
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // submit votes on behalf of the pool
     aToken.castVote(_proposalId);
 
     // _userB should not be able to express his/her vote on the proposal since the
     // vote was cast.
-    vm.expectRevert(bytes("too late to express, votes already cast"));
+    // TODO this isn't going to revert anymore
+    // vm.expectRevert(bytes("too late to express, votes already cast"));
     vm.prank(_userB);
     aToken.expressVote(_proposalId, _supportType);
   }
@@ -1591,10 +1599,11 @@ contract CastVote is AaveAtokenForkTest {
     uint256 _proposalId = _createAndSubmitProposal();
 
     // Wait until after the voting period
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Try to submit votes on behalf of the pool. It should fail.
-    vm.expectRevert(bytes("no votes expressed"));
+    // TODO this isn't going to fail anymore
+    // vm.expectRevert(bytes("no votes expressed"));
     aToken.castVote(_proposalId);
 
     // Express voting preference on the proposal.
@@ -1635,7 +1644,7 @@ contract CastVote is AaveAtokenForkTest {
     aToken.expressVote(_proposalId, _supportTypeB);
 
     // Wait until after the pool's voting period closes.
-    vm.roll(aToken.internalVotingPeriodEnd(_proposalId) + 1);
+    // TODO set up a random wait period??
 
     // Submit votes on behalf of the pool.
     aToken.castVote(_proposalId);
@@ -1657,6 +1666,53 @@ contract CastVote is AaveAtokenForkTest {
       if (_supportTypeB == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _transferAmount);
       // forgefmt: disable-end
     }
+  }
+
+  function _testVotesCanBeCastIncrementally(
+    address _userA,
+    address _userB,
+    uint8 _supportTypeA,
+    uint8 _supportTypeB
+  ) private {
+    require(_supportTypeA != _supportTypeB, "This test assumes the support types are different");
+    uint256 _weight = 1 ether;
+
+    // Deposit some funds.
+    _mintGovAndSupplyToAave(_userA, _weight);
+    _mintGovAndSupplyToAave(_userB, _weight);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // UserA expresses a voting preference on the proposal.
+    vm.prank(_userA);
+    aToken.expressVote(_proposalId, _supportTypeA);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
+      governor.proposalVotes(_proposalId);
+
+    if (_supportTypeA == uint8(VoteType.For)) assertEq(_forVotes, _weight);
+    if (_supportTypeA != uint8(VoteType.For)) assertEq(_forVotes, 0);
+    if (_supportTypeA == uint8(VoteType.Against)) assertEq(_againstVotes, _weight);
+    if (_supportTypeA != uint8(VoteType.Against)) assertEq(_againstVotes, 0);
+    if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weight);
+    if (_supportTypeA != uint8(VoteType.Abstain)) assertEq(_abstainVotes, 0);
+
+    // UserB expresses a voting preference on the proposal.
+    vm.prank(_userB);
+    aToken.expressVote(_proposalId, _supportTypeB);
+
+    // Submit votes on behalf of the pool.
+    aToken.castVote(_proposalId);
+
+    (_againstVotes, _forVotes, _abstainVotes) = governor.proposalVotes(_proposalId);
+
+    if (_supportTypeB == uint8(VoteType.For)) assertEq(_forVotes, _weight);
+    if (_supportTypeB == uint8(VoteType.Against)) assertEq(_againstVotes, _weight);
+    if (_supportTypeB == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _weight);
   }
 }
 

--- a/test/MockATokenFlexVoting.sol
+++ b/test/MockATokenFlexVoting.sol
@@ -5,9 +5,7 @@ import {IPool} from "aave-v3-core/contracts/interfaces/IPool.sol";
 import {ATokenFlexVoting} from "src/ATokenFlexVoting.sol";
 
 contract MockATokenFlexVoting is ATokenFlexVoting {
-  constructor(IPool _pool, address _governor)
-    ATokenFlexVoting(_pool, _governor)
-  {}
+  constructor(IPool _pool, address _governor) ATokenFlexVoting(_pool, _governor) {}
 
   function handleRepayment(address user, uint256 amount) external virtual onlyPool {
     // We need this because the Aave code we compile is ahead of the Aave code deployed on

--- a/test/MockATokenFlexVoting.sol
+++ b/test/MockATokenFlexVoting.sol
@@ -5,8 +5,8 @@ import {IPool} from "aave-v3-core/contracts/interfaces/IPool.sol";
 import {ATokenFlexVoting} from "src/ATokenFlexVoting.sol";
 
 contract MockATokenFlexVoting is ATokenFlexVoting {
-  constructor(IPool _pool, address _governor, uint32 _castVoteWindow)
-    ATokenFlexVoting(_pool, _governor, _castVoteWindow)
+  constructor(IPool _pool, address _governor)
+    ATokenFlexVoting(_pool, _governor)
   {}
 
   function handleRepayment(address user, uint256 amount) external virtual onlyPool {


### PR DESCRIPTION
Compare to the approach in #34. The idea here is that partial votes to `GovernorCountingFractional` will increment the amounts previously cast.

To give a concrete example:
* you have 100 weight to vote with
* the first time you vote, you cast 10 FOR, 20 AGAINST, 0 ABSTAIN
* the governor records 30 votes for you
* the next time you vote, you cast 30 FOR, 5 AGAINST, 10 ABSTAIN
* the governor now records 75 votes for you -- these new votes were added to your previous totals
* finally, you attempt to cast the following votes: 0 FOR, 25 AGAINST, 10 ABSTAIN
* the governor reverts, since if these votes were added to your previous votes you would have voted with a weight of 110, which is more than you have

Here's the gas report run with `forge test --gas-report` (I highlighted the two functions we care most about):

<img width="1078" alt="image" src="https://user-images.githubusercontent.com/7997618/215821338-d0370dee-3f83-456b-8fdc-8315941b3bb9.png">

This was done to help make a decision on the discussion [here](https://github.com/ScopeLift/flexible-voting/pull/31#discussion_r1089299026).

I didn't fix all of the tests on this branch (though there are only a couple more that are failing). I just verified that the main feature test that I wrote passed: `test_VotesCanBeCastIncrementally`. If we decide to go with this approach, more tests should be written.

This PR closes https://github.com/ScopeLift/flexible-voting/issues/18