### PR TITLE
Improve OZ remapping to shorten imports

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@
   # auto-detect solc versions.
   optimizer = true
   optimizer_runs = 10_000_000
-  remappings = ["openzeppelin-contracts/=lib/openzeppelin-contracts"]
+  remappings = ["openzeppelin-contracts/=lib/openzeppelin-contracts/contracts"]
   verbosity = 3
 
 [profile.ci]

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -9,8 +9,8 @@ import {GPv2SafeERC20} from "aave-v3-core/contracts/dependencies/gnosis/contract
 import {IAToken} from "aave-v3-core/contracts/interfaces/IAToken.sol";
 import {IAaveIncentivesController} from "aave-v3-core/contracts/interfaces/IAaveIncentivesController.sol";
 import {IPool} from "aave-v3-core/contracts/interfaces/IPool.sol";
-import {SafeCast} from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
-import {Checkpoints} from "openzeppelin-contracts/contracts/utils/Checkpoints.sol";
+import {SafeCast} from "openzeppelin-contracts/utils/math/SafeCast.sol";
+import {Checkpoints} from "openzeppelin-contracts/utils/Checkpoints.sol";
 import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 // forgefmt: disable-end

--- a/src/FractionalPool.sol
+++ b/src/FractionalPool.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
-import "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import "openzeppelin-contracts/utils/math/SafeCast.sol";
+import "openzeppelin-contracts/utils/math/Math.sol";
 import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 

--- a/src/GovernorCountingFractional.sol
+++ b/src/GovernorCountingFractional.sol
@@ -6,9 +6,9 @@ pragma solidity ^0.8.0;
 // Disabling forgefmt to stay consistent with OZ's style.
 // forgefmt: disable-start
 
-import "openzeppelin-contracts/contracts/governance/Governor.sol";
-import "openzeppelin-contracts/contracts/governance/compatibility/GovernorCompatibilityBravo.sol";
-import "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+import "openzeppelin-contracts/governance/Governor.sol";
+import "openzeppelin-contracts/governance/compatibility/GovernorCompatibilityBravo.sol";
+import "openzeppelin-contracts/utils/math/SafeCast.sol";
 
 /**
  * @notice Extension of {Governor} for 3 option fractional vote counting. When voting, a delegate may split their vote

--- a/test/ATokenFlexVotingFork.t.sol
+++ b/test/ATokenFlexVotingFork.t.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.8.10;
 // forgefmt: disable-start
 import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
-import { ERC20 } from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
-import { IVotes } from "openzeppelin-contracts/contracts/governance/utils/IVotes.sol";
+import { ERC20 } from "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import { IVotes } from "openzeppelin-contracts/governance/utils/IVotes.sol";
 
 import { AaveOracle } from 'aave-v3-core/contracts/misc/AaveOracle.sol';
 import { AToken } from "aave-v3-core/contracts/protocol/tokenization/AToken.sol";

--- a/test/FractionalGovernor.sol
+++ b/test/FractionalGovernor.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.10;
 
 import "../src/GovernorCountingFractional.sol";
-import "openzeppelin-contracts/contracts/governance/extensions/GovernorVotes.sol";
+import "openzeppelin-contracts/governance/extensions/GovernorVotes.sol";
 
 contract FractionalGovernor is GovernorVotes, GovernorCountingFractional {
   constructor(string memory name_, IVotes token_) Governor(name_) GovernorVotes(token_) {}

--- a/test/GovToken.sol
+++ b/test/GovToken.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.10;
 
-import {ERC20Votes} from "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Votes.sol";
-import {ERC20Permit} from
-  "openzeppelin-contracts/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
-import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import {ERC20Votes} from "openzeppelin-contracts/token/ERC20/extensions/ERC20Votes.sol";
+import {ERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
+import {ERC20} from "openzeppelin-contracts/token/ERC20/ERC20.sol";
 
 contract GovToken is ERC20Votes {
   constructor() ERC20("Governance Token", "GOV") ERC20Permit("GOV") {}

--- a/test/GovernorCountingFractional.t.sol
+++ b/test/GovernorCountingFractional.t.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.10;
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {FractionalPool, IVotingToken, IFractionalGovernor} from "../src/FractionalPool.sol";
-import "openzeppelin-contracts/contracts/governance/compatibility/GovernorCompatibilityBravo.sol";
+import "openzeppelin-contracts/governance/compatibility/GovernorCompatibilityBravo.sol";
 import "solmate/utils/FixedPointMathLib.sol";
 
 import "./GovToken.sol";


### PR DESCRIPTION
This should also make it easier to import this library to implement fractional governors, e.g. [here](https://github.com/gitcoinco/Alpha-Governor-Upgrade/pull/17)