### PR TITLE
L-02 Incomplete Docstrings

### DIFF
--- a/src/GovernorCountingFractional.sol
+++ b/src/GovernorCountingFractional.sol
@@ -57,6 +57,14 @@ abstract contract GovernorCountingFractional is Governor {
     }
 
     /**
+     * @dev Get the number of votes cast on proposal `proposalId` by account `account`.
+     * Useful if you intend to allow delegates to cast rolling, partial votes.
+     */
+    function voteWeightCast(uint256 proposalId, address account) public view returns (uint128) {
+      return _proposalVotersWeightCast[proposalId][account];
+    }
+
+    /**
      * @dev Accessor to the internal vote counts.
      */
     function proposalVotes(uint256 proposalId)

--- a/test/GovernorCountingFractional.t.sol
+++ b/test/GovernorCountingFractional.t.sol
@@ -756,8 +756,7 @@ contract GovernorCountingFractionalTest is Test {
     assertEq(_againstVotes, _actualAgainstVotes);
     assertEq(_abstainVotes, _actualAbstainVotes);
     assertEq(
-      governor.voteWeightCast(_proposalId, _voter.addr),
-      _forVotes + _againstVotes + _abstainVotes
+      governor.voteWeightCast(_proposalId, _voter.addr), _forVotes + _againstVotes + _abstainVotes
     );
   }
 
@@ -856,8 +855,8 @@ contract GovernorCountingFractionalTest is Test {
     assertEq(_firstVote.abstainVotes + _secondVote.abstainVotes, _actualAbstainVotes);
     assertEq(
       governor.voteWeightCast(_proposalId, _voter.addr),
-      _firstVote.againstVotes + _firstVote.forVotes + _firstVote.abstainVotes +
-      _secondVote.againstVotes + _secondVote.forVotes + _secondVote.abstainVotes
+      _firstVote.againstVotes + _firstVote.forVotes + _firstVote.abstainVotes
+        + _secondVote.againstVotes + _secondVote.forVotes + _secondVote.abstainVotes
     );
 
     // If the entire weight was cast; further votes are not possible.
@@ -893,9 +892,9 @@ contract GovernorCountingFractionalTest is Test {
     );
     assertEq(
       governor.voteWeightCast(_proposalId, _voter.addr),
-      _firstVote.againstVotes + _firstVote.forVotes + _firstVote.abstainVotes +
-      _secondVote.againstVotes + _secondVote.forVotes + _secondVote.abstainVotes +
-      _thirdVote.againstVotes + _thirdVote.forVotes + _thirdVote.abstainVotes
+      _firstVote.againstVotes + _firstVote.forVotes + _firstVote.abstainVotes
+        + _secondVote.againstVotes + _secondVote.forVotes + _secondVote.abstainVotes
+        + _thirdVote.againstVotes + _thirdVote.forVotes + _thirdVote.abstainVotes
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/ScopeLift/flexible-voting/issues/37

Although docstrings are present above the `_countVoteNominal` and `_countVoteFractional` functions, they do not provide complete information about the purpose of these functions and the parameters passed to them.