### PR TITLE
N-01 OpenZeppelin Imports in Incorrect Format

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,10 @@
   # auto-detect solc versions.
   optimizer = true
   optimizer_runs = 10_000_000
-  remappings = ["openzeppelin-contracts/=lib/openzeppelin-contracts/contracts"]
+  remappings = [
+    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts",
+    "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts",
+  ]
   verbosity = 3
 
 [profile.ci]

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,10 +4,7 @@
   # auto-detect solc versions.
   optimizer = true
   optimizer_runs = 10_000_000
-  remappings = [
-    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts",
-    "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts",
-  ]
+  remappings = ["@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts"]
   verbosity = 3
 
 [profile.ci]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "flexible-voting",
+  "version": "1.0.0",
+  "description": "Flexible Voting is an extension to the widely used OpenZeppelin DAO Governor that enables delegates to split their voting weight across For/Against/Abstain options and cast rolling votes for a given proposal.",
+  "author": "Contributors to https://github.com/ScopeLift/flexible-voting",
+  "files": [
+    "src/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ScopeLift/flexible-voting.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ScopeLift/flexible-voting/issues"
+  },
+  "homepage": "https://github.com/ScopeLift/flexible-voting#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flexible-voting",
   "version": "1.0.0",
-  "description": "Flexible Voting is an extension to the widely used OpenZeppelin DAO Governor that enables delegates to split their voting weight across For/Against/Abstain options and cast rolling votes for a given proposal.",
+  "description": "Flexible Voting is an extension to the widely used OpenZeppelin DAO Governor that enables delegates to split their voting weight across For/Against/Abstain options and cast rolling votes for a given proposal. This file is included for compatibility with npm based development frameworks such as Hardhat.",
   "author": "Contributors to https://github.com/ScopeLift/flexible-voting",
   "files": [
     "src/*"

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -9,8 +9,8 @@ import {GPv2SafeERC20} from "aave-v3-core/contracts/dependencies/gnosis/contract
 import {IAToken} from "aave-v3-core/contracts/interfaces/IAToken.sol";
 import {IAaveIncentivesController} from "aave-v3-core/contracts/interfaces/IAaveIncentivesController.sol";
 import {IPool} from "aave-v3-core/contracts/interfaces/IPool.sol";
-import {SafeCast} from "openzeppelin-contracts/utils/math/SafeCast.sol";
-import {Checkpoints} from "openzeppelin-contracts/utils/Checkpoints.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
 import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 // forgefmt: disable-end

--- a/src/FractionalPool.sol
+++ b/src/FractionalPool.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import "openzeppelin-contracts/utils/math/SafeCast.sol";
-import "openzeppelin-contracts/utils/math/Math.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 

--- a/src/GovernorCountingFractional.sol
+++ b/src/GovernorCountingFractional.sol
@@ -6,9 +6,9 @@ pragma solidity ^0.8.0;
 // Disabling forgefmt to stay consistent with OZ's style.
 // forgefmt: disable-start
 
-import {Governor} from "openzeppelin-contracts/governance/Governor.sol";
-import {GovernorCompatibilityBravo} from "openzeppelin-contracts/governance/compatibility/GovernorCompatibilityBravo.sol";
-import {SafeCast} from "openzeppelin-contracts/utils/math/SafeCast.sol";
+import {Governor} from "@openzeppelin/contracts/governance/Governor.sol";
+import {GovernorCompatibilityBravo} from "@openzeppelin/contracts/governance/compatibility/GovernorCompatibilityBravo.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /**
  * @notice Extension of {Governor} for 3 option fractional vote counting. When voting, a delegate may split their vote

--- a/test/ATokenFlexVotingFork.t.sol
+++ b/test/ATokenFlexVotingFork.t.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.8.10;
 // forgefmt: disable-start
 import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
-import { ERC20 } from "openzeppelin-contracts/token/ERC20/ERC20.sol";
-import { IVotes } from "openzeppelin-contracts/governance/utils/IVotes.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IVotes } from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 
 import { AaveOracle } from 'aave-v3-core/contracts/misc/AaveOracle.sol';
 import { AToken } from "aave-v3-core/contracts/protocol/tokenization/AToken.sol";

--- a/test/FractionalGovernor.sol
+++ b/test/FractionalGovernor.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.10;
 
 import "../src/GovernorCountingFractional.sol";
-import "openzeppelin-contracts/governance/extensions/GovernorVotes.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
 
 contract FractionalGovernor is GovernorVotes, GovernorCountingFractional {
   constructor(string memory name_, IVotes token_) Governor(name_) GovernorVotes(token_) {}

--- a/test/GovToken.sol
+++ b/test/GovToken.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.10;
 
-import {ERC20Votes} from "openzeppelin-contracts/token/ERC20/extensions/ERC20Votes.sol";
-import {ERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
-import {ERC20} from "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import {ERC20Votes} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract GovToken is ERC20Votes {
   constructor() ERC20("Governance Token", "GOV") ERC20Permit("GOV") {}

--- a/test/GovernorCountingFractional.t.sol
+++ b/test/GovernorCountingFractional.t.sol
@@ -4,12 +4,13 @@ pragma solidity >=0.8.10;
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {FractionalPool, IVotingToken, IFractionalGovernor} from "../src/FractionalPool.sol";
-import "openzeppelin-contracts/governance/compatibility/GovernorCompatibilityBravo.sol";
-import "solmate/utils/FixedPointMathLib.sol";
+import {GovernorCompatibilityBravo} from
+  "@openzeppelin/contracts/governance/compatibility/GovernorCompatibilityBravo.sol";
+import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
-import "./GovToken.sol";
-import "./FractionalGovernor.sol";
-import "./ProposalReceiverMock.sol";
+import {GovToken} from "./GovToken.sol";
+import {FractionalGovernor, IVotes, IGovernor} from "./FractionalGovernor.sol";
+import {ProposalReceiverMock} from "./ProposalReceiverMock.sol";
 
 contract GovernorCountingFractionalTest is Test {
   using FixedPointMathLib for uint256;


### PR DESCRIPTION
[OZ recommends]( https://docs.openzeppelin.com/contracts/4.x/) that contracts import its code using the node style so that they have out-of-the box compatibility with [hardhat](https://github.com/NomicFoundation/hardhat).

Note that CI will fail because of a formatting error. I've left the formatting change out of this PR to (a) keep it clean and specific to the issue above and (b) because that formatting error has already been fixed in #40 which will merge before this.

I manually tested that this can now be imported into a hardhat project without issue. Steps to do this were:
1. `mkdir` + `cd` into a new directory
1. `npm init`
3. `npx hardhat`
4. `npm install @openzeppelin/contracts`
5. `npm install ScopeLift/flexible-voting#oz-audit-fixes-N01-hardhat-friendly-imports --save`
6. copy [this file](https://github.com/ScopeLift/flexible-voting/blob/master/test/FractionalGovernor.sol) into `/contracts`
7. modify the file so that imports look like:
    ```solidity
      import "flexible-voting/src/GovernorCountingFractional.sol";
      import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
    ```
8. `npx hardhat compile`

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/7997618/225436392-7036ca35-9f6a-41dd-91ec-1858be823025.png">
