### PR TITLE
Add Compound V3 client contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,32 +39,33 @@ jobs:
 
       - name: Run tests
         run: forge test
-  #
-  # fmt:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #
-  #     - name: Install Foundry
-  #       uses: foundry-rs/foundry-toolchain@v1
-  #       with:
-  #         version: nightly
-  #
-  #     - name: Install scopelint
-  #       uses: engineerd/configurator@v0.0.8
-  #       with:
-  #         name: scopelint
-  #         repo: ScopeLift/scopelint
-  #         fromGitHubReleases: true
-  #         version: latest
-  #         pathInArchive: scopelint-x86_64-linux/scopelint
-  #         urlTemplate: https://github.com/ScopeLift/scopelint/releases/download/{{version}}/scopelint-x86_64-linux.tar.xz
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #
-  #     - name: Check formatting
-  #       run: |
-  #         scopelint --version
-  #         scopelint check
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install scopelint
+        uses: engineerd/configurator@v0.0.8
+        with:
+          name: scopelint
+          repo: ScopeLift/scopelint
+          fromGitHubReleases: true
+          version: latest
+          pathInArchive: scopelint-x86_64-linux/scopelint
+          urlTemplate: https://github.com/ScopeLift/scopelint/releases/download/{{version}}/scopelint-x86_64-linux.tar.xz
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check formatting
+        run: forge fmt --check
+        # run: |
+        #   scopelint --version
+        #   scopelint check
 
   # TODO figure out why this is failing and uncomment
   # slither-analyze:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build contracts
         run: |
           forge --version
-          forge build --sizes
+          forge build
   test:
     runs-on: ubuntu-latest
     steps:
@@ -38,32 +38,32 @@ jobs:
 
       - name: Run tests
         run: forge test
-
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-
-      - name: Install scopelint
-        uses: engineerd/configurator@v0.0.8
-        with:
-          name: scopelint
-          repo: ScopeLift/scopelint
-          fromGitHubReleases: true
-          version: latest
-          pathInArchive: scopelint-x86_64-linux/scopelint
-          urlTemplate: https://github.com/ScopeLift/scopelint/releases/download/{{version}}/scopelint-x86_64-linux.tar.xz
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check formatting
-        run: |
-          scopelint --version
-          scopelint check
+  #
+  # fmt:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #
+  #     - name: Install Foundry
+  #       uses: foundry-rs/foundry-toolchain@v1
+  #       with:
+  #         version: nightly
+  #
+  #     - name: Install scopelint
+  #       uses: engineerd/configurator@v0.0.8
+  #       with:
+  #         name: scopelint
+  #         repo: ScopeLift/scopelint
+  #         fromGitHubReleases: true
+  #         version: latest
+  #         pathInArchive: scopelint-x86_64-linux/scopelint
+  #         urlTemplate: https://github.com/ScopeLift/scopelint/releases/download/{{version}}/scopelint-x86_64-linux.tar.xz
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #
+  #     - name: Check formatting
+  #       run: |
+  #         scopelint --version
+  #         scopelint check
 
   # TODO figure out why this is failing and uncomment
   # slither-analyze:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: forge test
+        run: forge test -vvvv
   #
   # fmt:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,16 @@ jobs:
         with:
           version: nightly
 
-      - name: Install scopelint
-        uses: engineerd/configurator@v0.0.8
-        with:
-          name: scopelint
-          repo: ScopeLift/scopelint
-          fromGitHubReleases: true
-          version: latest
-          pathInArchive: scopelint-x86_64-linux/scopelint
-          urlTemplate: https://github.com/ScopeLift/scopelint/releases/download/{{version}}/scopelint-x86_64-linux.tar.xz
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Install scopelint
+      #   uses: engineerd/configurator@v0.0.8
+      #   with:
+      #     name: scopelint
+      #     repo: ScopeLift/scopelint
+      #     fromGitHubReleases: true
+      #     version: latest
+      #     pathInArchive: scopelint-x86_64-linux/scopelint
+      #     urlTemplate: https://github.com/ScopeLift/scopelint/releases/download/{{version}}/scopelint-x86_64-linux.tar.xz
+      #     token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check formatting
         run: forge fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
+  MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
   OPTIMISM_RPC_URL: ${{ secrets.OPTIMISM_RPC_URL }}
 
 jobs:
@@ -37,7 +38,7 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: forge test -vvvv
+        run: forge test
   #
   # fmt:
   #   runs-on: ubuntu-latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,4 +13,4 @@
 	branch = v4.8.0
 [submodule "lib/comet"]
 	path = lib/comet
-	url = https://github.com/compound-finance/comet
+	url = https://github.com/davidlaprade/comet

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts
 	branch = v4.8.0
+[submodule "lib/comet"]
+	path = lib/comet
+	url = https://github.com/compound-finance/comet

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,8 +18,8 @@
   optimizer = false
 
 [rpc_endpoints]
-  optimism = "${OPTIMISM_RPC_URL}"
   mainnet = "${MAINNET_RPC_URL}"
+  optimism = "${OPTIMISM_RPC_URL}"
 
 [fmt]
   bracket_spacing = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,7 @@
 
 [rpc_endpoints]
   optimism = "${OPTIMISM_RPC_URL}"
+  mainnet = "${MAINNET_RPC_URL}"
 
 [fmt]
   bracket_spacing = false

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -13,6 +13,8 @@ import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
 import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";
+
+import {FlexVotingClient} from "src/FlexVotingClient.sol";
 // forgefmt: disable-end
 
 /// @notice This is an extension of Aave V3's AToken contract which makes it possible for AToken
@@ -39,46 +41,13 @@ import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 /// The original AToken that this contract extends is viewable here:
 ///
 ///   https://github.com/aave/aave-v3-core/blob/c38c6276/contracts/protocol/tokenization/AToken.sol
-contract ATokenFlexVoting is AToken {
-  using SafeCast for uint256;
+contract ATokenFlexVoting is AToken, FlexVotingClient {
   using Checkpoints for Checkpoints.History;
-
-  /// @notice The voting options corresponding to those used in the Governor.
-  enum VoteType {
-    Against,
-    For,
-    Abstain
-  }
-
-  /// @notice Data structure to store vote preferences expressed by depositors.
-  struct ProposalVote {
-    uint128 againstVotes;
-    uint128 forVotes;
-    uint128 abstainVotes;
-  }
-
-  /// @notice Map proposalId to an address to whether they have voted on this proposal.
-  mapping(uint256 => mapping(address => bool)) private proposalVotersHasVoted;
-
-  /// @notice Map proposalId to vote totals expressed on this proposal.
-  mapping(uint256 => ProposalVote) public proposalVotes;
-
-  /// @notice The governor contract associated with this governance token. It
-  /// must be one that supports fractional voting, e.g. GovernorCountingFractional.
-  IFractionalGovernor public immutable GOVERNOR;
-
-  /// @notice Mapping from address to stored (not rebased) balance checkpoint history.
-  mapping(address => Checkpoints.History) private balanceCheckpoints;
-
-  /// @notice History of total stored (not rebased) balances.
-  Checkpoints.History private totalDepositCheckpoints;
 
   /// @dev Constructor.
   /// @param _pool The address of the Pool contract
   /// @param _governor The address of the flex-voting-compatible governance contract.
-  constructor(IPool _pool, address _governor) AToken(_pool) {
-    GOVERNOR = IFractionalGovernor(_governor);
-  }
+  constructor(IPool _pool, address _governor) AToken(_pool) FlexVotingClient(_governor) {}
 
   // forgefmt: disable-start
   //===========================================================================
@@ -109,7 +78,7 @@ contract ATokenFlexVoting is AToken {
       params
     );
 
-    selfDelegate();
+    FlexVotingClient.selfDelegate();
   }
 
   /// Note: this has been modified from Aave v3's MintableIncentivizedERC20 to
@@ -118,8 +87,10 @@ contract ATokenFlexVoting is AToken {
   /// @inheritdoc MintableIncentivizedERC20
   function _burn(address account, uint128 amount) internal override {
     MintableIncentivizedERC20._burn(account, amount);
-    _checkpointRawBalanceOf(account);
-    totalDepositCheckpoints.push(totalDepositCheckpoints.latest() - amount);
+    FlexVotingClient._checkpointRawBalanceOf(account);
+    FlexVotingClient.totalDepositCheckpoints.push(
+      FlexVotingClient.totalDepositCheckpoints.latest() - amount
+    );
   }
 
   /// Note: this has been modified from Aave v3's MintableIncentivizedERC20 to
@@ -128,8 +99,10 @@ contract ATokenFlexVoting is AToken {
   /// @inheritdoc MintableIncentivizedERC20
   function _mint(address account, uint128 amount) internal override {
     MintableIncentivizedERC20._mint(account, amount);
-    _checkpointRawBalanceOf(account);
-    totalDepositCheckpoints.push(totalDepositCheckpoints.latest() + amount);
+    FlexVotingClient._checkpointRawBalanceOf(account);
+    FlexVotingClient.totalDepositCheckpoints.push(
+      FlexVotingClient.totalDepositCheckpoints.latest() + amount
+    );
   }
 
   /// @dev This has been modified from Aave v3's AToken contract to checkpoint raw balances
@@ -145,136 +118,16 @@ contract ATokenFlexVoting is AToken {
     bool validate
   ) internal virtual override {
     AToken._transfer(from, to, amount, validate);
-    _checkpointRawBalanceOf(from);
-    _checkpointRawBalanceOf(to);
+    FlexVotingClient._checkpointRawBalanceOf(from);
+    FlexVotingClient._checkpointRawBalanceOf(to);
   }
   //===========================================================================
   // END: Aave overrides
   //===========================================================================
   // forgefmt: disable-end
 
-  // Self-delegation cannot be done in the constructor because the aToken is
-  // just a proxy -- it won't share an address with the implementation (i.e.
-  // this code). Instead we do it at the end of `initialize`. But even that won't
-  // handle already-initialized aTokens. For those, we'll need to self-delegate
-  // during the upgrade process. More details in these issues:
-  // https://github.com/aave/aave-v3-core/pull/774
-  // https://github.com/ScopeLift/flexible-voting/issues/16
-  function selfDelegate() public {
-    IVotingToken(GOVERNOR.token()).delegate(address(this));
-  }
-
-  /// @notice Allow a depositor to express their voting preference for a given
-  /// proposal. Their preference is recorded internally but not moved to the
-  /// Governor until `castVote` is called.
-  /// @param proposalId The proposalId in the associated Governor
-  /// @param support The depositor's vote preferences in accordance with the `VoteType` enum.
-  function expressVote(uint256 proposalId, uint8 support) external {
-    uint256 weight = getPastStoredBalance(msg.sender, GOVERNOR.proposalSnapshot(proposalId));
-    require(weight > 0, "no weight");
-
-    require(!proposalVotersHasVoted[proposalId][msg.sender], "already voted");
-    proposalVotersHasVoted[proposalId][msg.sender] = true;
-
-    if (support == uint8(VoteType.Against)) {
-      proposalVotes[proposalId].againstVotes += SafeCast.toUint128(weight);
-    } else if (support == uint8(VoteType.For)) {
-      proposalVotes[proposalId].forVotes += SafeCast.toUint128(weight);
-    } else if (support == uint8(VoteType.Abstain)) {
-      proposalVotes[proposalId].abstainVotes += SafeCast.toUint128(weight);
-    } else {
-      revert("invalid support value, must be included in VoteType enum");
-    }
-  }
-
-  /// @notice Causes this contract to cast a vote to the Governor for all of the
-  /// accumulated votes expressed by users. Uses the sum of all raw (unrebased) balances
-  /// to proportionally split its voting weight. Can be called by anyone. Can be called
-  /// multiple times during the lifecycle of a given proposal.
-  /// @param proposalId The ID of the proposal which the Pool will now vote on.
-  function castVote(uint256 proposalId) external {
-    ProposalVote storage _proposalVote = proposalVotes[proposalId];
-    require(
-      _proposalVote.forVotes + _proposalVote.againstVotes + _proposalVote.abstainVotes > 0,
-      "no votes expressed"
-    );
-    uint256 _proposalSnapshotBlockNumber = GOVERNOR.proposalSnapshot(proposalId);
-
-    // We use the snapshot of total raw balances to determine the weight with
-    // which to vote. We do this for two reasons:
-    //   (1) We cannot use the proposalVote numbers alone, since some people with
-    //       balances at the snapshot might never express their preferences. If a
-    //       large holder never expressed a preference, but this contract nevertheless
-    //       cast votes to the governor with all of its weight, then other users may
-    //       effectively have *increased* their voting weight because someone else
-    //       didn't participate, which creates all kinds of bad incentives.
-    //   (2) Other people might have already expressed their preferences on this
-    //       proposal and had those preferences submitted to the governor by an
-    //       earlier call to this function. The weight of those preferences
-    //       should still be taken into consideration when determining how much
-    //       weight to vote with this time.
-    // Using the total raw balance to proportion votes in this way means that in
-    // many circumstances this function will not cast votes with all of its
-    // weight.
-    uint256 _totalRawBalanceAtSnapshot = getPastTotalBalance(_proposalSnapshotBlockNumber);
-
-    // We need 256 bits because of the multiplication we're about to do.
-    uint256 _votingWeightAtSnapshot = IVotingToken(address(_underlyingAsset)).getPastVotes(
-      address(this), _proposalSnapshotBlockNumber
-    );
-
-    //      forVotesRaw          forVoteWeight
-    // --------------------- = ------------------
-    //     totalRawBalance      totalVoteWeight
-    //
-    // forVoteWeight = forVotesRaw * totalVoteWeight / totalRawBalance
-    uint128 _forVotesToCast = SafeCast.toUint128(
-      (_votingWeightAtSnapshot * _proposalVote.forVotes) / _totalRawBalanceAtSnapshot
-    );
-    uint128 _againstVotesToCast = SafeCast.toUint128(
-      (_votingWeightAtSnapshot * _proposalVote.againstVotes) / _totalRawBalanceAtSnapshot
-    );
-    uint128 _abstainVotesToCast = SafeCast.toUint128(
-      (_votingWeightAtSnapshot * _proposalVote.abstainVotes) / _totalRawBalanceAtSnapshot
-    );
-
-    // This param is ignored by the governor when voting with fractional
-    // weights. It makes no difference what vote type this is.
-    uint8 unusedSupportParam = uint8(VoteType.Abstain);
-
-    // Clear the stored votes so that we don't double-cast them.
-    delete proposalVotes[proposalId];
-
-    bytes memory fractionalizedVotes =
-      abi.encodePacked(_againstVotesToCast, _forVotesToCast, _abstainVotesToCast);
-    GOVERNOR.castVoteWithReasonAndParams(
-      proposalId,
-      unusedSupportParam,
-      "rolled-up vote from aToken holders", // Reason string.
-      fractionalizedVotes
-    );
-  }
-
   /// @notice Returns the _user's current balance in storage.
-  function _rawBalanceOf(address _user) internal view returns (uint256) {
+  function _rawBalanceOf(address _user) internal view override returns (uint256) {
     return _userState[_user].balance;
-  }
-
-  /// @notice Checkpoints the _user's current raw balance.
-  function _checkpointRawBalanceOf(address _user) internal {
-    balanceCheckpoints[_user].push(_rawBalanceOf(_user));
-  }
-
-  /// @notice Returns the _user's balance in storage at the _blockNumber.
-  /// @param _user The account that's historical balance will be looked up.
-  /// @param _blockNumber The block at which to lookup the _user's balance.
-  function getPastStoredBalance(address _user, uint256 _blockNumber) public view returns (uint256) {
-    return balanceCheckpoints[_user].getAtProbablyRecentBlock(_blockNumber);
-  }
-
-  /// @notice Returns the total stored balance of all users at _blockNumber.
-  /// @param _blockNumber The block at which to lookup the total stored balance.
-  function getPastTotalBalance(uint256 _blockNumber) public view returns (uint256) {
-    return totalDepositCheckpoints.getAtProbablyRecentBlock(_blockNumber);
   }
 }

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -88,8 +88,8 @@ contract ATokenFlexVoting is AToken, FlexVotingClient {
   function _burn(address account, uint128 amount) internal override {
     MintableIncentivizedERC20._burn(account, amount);
     FlexVotingClient._checkpointRawBalanceOf(account);
-    FlexVotingClient.totalDepositCheckpoints.push(
-      FlexVotingClient.totalDepositCheckpoints.latest() - amount
+    FlexVotingClient.totalBalanceCheckpoints.push(
+      FlexVotingClient.totalBalanceCheckpoints.latest() - amount
     );
   }
 
@@ -100,8 +100,8 @@ contract ATokenFlexVoting is AToken, FlexVotingClient {
   function _mint(address account, uint128 amount) internal override {
     MintableIncentivizedERC20._mint(account, amount);
     FlexVotingClient._checkpointRawBalanceOf(account);
-    FlexVotingClient.totalDepositCheckpoints.push(
-      FlexVotingClient.totalDepositCheckpoints.latest() + amount
+    FlexVotingClient.totalBalanceCheckpoints.push(
+      FlexVotingClient.totalBalanceCheckpoints.latest() + amount
     );
   }
 

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -4,16 +4,10 @@ pragma solidity 0.8.10;
 // forgefmt: disable-start
 import {AToken} from "aave-v3-core/contracts/protocol/tokenization/AToken.sol";
 import {MintableIncentivizedERC20} from "aave-v3-core/contracts/protocol/tokenization/base/MintableIncentivizedERC20.sol";
-import {Errors} from "aave-v3-core/contracts/protocol/libraries/helpers/Errors.sol";
-import {GPv2SafeERC20} from "aave-v3-core/contracts/dependencies/gnosis/contracts/GPv2SafeERC20.sol";
-import {IAToken} from "aave-v3-core/contracts/interfaces/IAToken.sol";
 import {IAaveIncentivesController} from "aave-v3-core/contracts/interfaces/IAaveIncentivesController.sol";
 import {IPool} from "aave-v3-core/contracts/interfaces/IPool.sol";
-import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
 
-import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
-import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 import {FlexVotingClient} from "src/FlexVotingClient.sol";
 // forgefmt: disable-end
 

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -11,9 +11,9 @@ import {IAaveIncentivesController} from "aave-v3-core/contracts/interfaces/IAave
 import {IPool} from "aave-v3-core/contracts/interfaces/IPool.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
+
 import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";
-
 import {FlexVotingClient} from "src/FlexVotingClient.sol";
 // forgefmt: disable-end
 

--- a/src/ATokenFlexVoting.sol
+++ b/src/ATokenFlexVoting.sol
@@ -78,7 +78,7 @@ contract ATokenFlexVoting is AToken, FlexVotingClient {
       params
     );
 
-    FlexVotingClient.selfDelegate();
+    FlexVotingClient._selfDelegate();
   }
 
   /// Note: this has been modified from Aave v3's MintableIncentivizedERC20 to

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -6,12 +6,10 @@ import { CometConfiguration } from "comet/CometConfiguration.sol";
 
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
+import {FlexVotingClient} from "src/FlexVotingClient.sol";
 
 // TODO add description
-contract CometFlexVoting is Comet {
-  /// @notice The governor contract associated with this contract's baseToken. It
-  /// must be one that supports fractional voting, e.g. GovernorCountingFractional.
-  IFractionalGovernor public immutable GOVERNOR;
+contract CometFlexVoting is Comet, FlexVotingClient {
 
   /// @dev Constructor.
   /// @param _config The configuration struct for this Comet instance.
@@ -19,16 +17,14 @@ contract CometFlexVoting is Comet {
   constructor(
     CometConfiguration.Configuration memory _config,
     address _governor
-  ) Comet(_config) {
-    GOVERNOR = IFractionalGovernor(_governor);
+  ) Comet(_config) FlexVotingClient(_governor) {
     selfDelegate();
   }
 
-  // This is called within the constructor, but we want it to be publically
-  // available if/when existing cTokens are upgraded.
-  // TODO can cTokens be upgraded?
-  function selfDelegate() public {
-    IVotingToken(GOVERNOR.token()).delegate(address(this));
+  /// @notice Returns the _user's current balance in storage.
+  function _rawBalanceOf(address account) internal view override returns (uint256) {
+    int104 _principal = userBasic[account].principal;
+    return _principal > 0 ? uint256(int256(_principal)) : 0;
   }
 
   // forgefmt: disable-start

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -7,7 +7,35 @@ import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
 
 import {FlexVotingClient} from "src/FlexVotingClient.sol";
 
-// TODO add description
+/// @notice This is an extension of Compound V3's Comet contract which makes it
+/// possible for Comet token holders to still vote on governance proposals. This
+/// way, holders of governance tokens do not have to choose between earning
+/// yield on Compound and voting. They can do both.
+///
+/// This extension has the following requirements:
+///   (a) the base token be a governance token
+///   (b) the base token's governor contract support flexible voting (see
+///       GovernorCountingFractional)
+///
+/// If these requirements are met, base token depositors can call
+/// `Comet.expressVote` to signal their preference on open governance proposals.
+/// When they do so, this extension records that preference with weight
+/// proportional to the users's Comet balance at the proposal snapshot.
+///
+/// At any point after voting preferences have been expressed, Comet's public
+/// `castVote` function may be called to roll up all internal voting records
+/// into a single delegated vote to the Governor contract -- a vote which
+/// specifies the exact For/Abstain/Against totals expressed by Comet holders.
+/// Votes can be rolled up and cast in this manner multiple times for a given
+/// proposal.
+///
+/// Participating in governance via Comet voting is completely optional. Users
+/// otherwise still supply, borrow, and hold tokens with Compound as usual.
+///
+/// The original Comet that this contract was developed against can be viewed
+/// here:
+///
+///   https://github.com/compound-finance/comet/blob/3780c06b4eaa80a8c78e0ff770a7e8a1518db75e/contracts/Comet.sol
 contract CometFlexVoting is Comet, FlexVotingClient {
   using Checkpoints for Checkpoints.History;
 

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.10;
 
 import { Comet } from "comet/Comet.sol";
 import { CometConfiguration } from "comet/CometConfiguration.sol";
+import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
 
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
@@ -10,6 +11,7 @@ import {FlexVotingClient} from "src/FlexVotingClient.sol";
 
 // TODO add description
 contract CometFlexVoting is Comet, FlexVotingClient {
+  using Checkpoints for Checkpoints.History;
 
   /// @dev Constructor.
   /// @param _config The configuration struct for this Comet instance.
@@ -31,6 +33,31 @@ contract CometFlexVoting is Comet, FlexVotingClient {
   //===========================================================================
   // BEGIN: Comet overrides
   //===========================================================================
+  //
+  // This function is called anytime the underlying balance is changed.
+  function updateBasePrincipal(
+    address _account,
+    UserBasic memory _userBasic,
+    int104 _principalNew
+  ) internal override {
+    int104 _principalInitial = userBasic[_account].principal;
+    int224 _initTotalDeposits = int224(FlexVotingClient.totalDepositCheckpoints.latest());
+
+    Comet.updateBasePrincipal(_account, _userBasic, _principalNew);
+
+    // Checkpoint the account's balance.
+    FlexVotingClient._checkpointRawBalanceOf(_account);
+
+    // TODO why not just do:
+    // baseToken.balanceOf(address(this)) ?
+
+    // Checkpoint the pool's total balance.
+    int104 _principalDelta = _principalNew - _principalInitial;
+    int224 _newTotalDeposits = _initTotalDeposits + _principalDelta;
+    // TODO Can _newTotalDeposits ever go negative?
+    FlexVotingClient.totalDepositCheckpoints.push(uint224(_newTotalDeposits));
+  }
+  //
   //===========================================================================
   // END: Comet overrides
   //===========================================================================

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.10;
 
-import { Comet } from "comet/Comet.sol";
-import { CometConfiguration } from "comet/CometConfiguration.sol";
+import {Comet} from "comet/Comet.sol";
+import {CometConfiguration} from "comet/CometConfiguration.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
 
 import {IVotingToken} from "src/interfaces/IVotingToken.sol";
@@ -16,10 +16,10 @@ contract CometFlexVoting is Comet, FlexVotingClient {
   /// @dev Constructor.
   /// @param _config The configuration struct for this Comet instance.
   /// @param _governor The address of the flex-voting-compatible governance contract.
-  constructor(
-    CometConfiguration.Configuration memory _config,
-    address _governor
-  ) Comet(_config) FlexVotingClient(_governor) {
+  constructor(CometConfiguration.Configuration memory _config, address _governor)
+    Comet(_config)
+    FlexVotingClient(_governor)
+  {
     selfDelegate();
   }
 
@@ -34,7 +34,7 @@ contract CometFlexVoting is Comet, FlexVotingClient {
   // BEGIN: Comet overrides
   //===========================================================================
   //
-  // This function is called any time the underlying balance is changed.
+// This function is called any time the underlying balance is changed.
   function updateBasePrincipal(
     address _account,
     UserBasic memory _userBasic,
@@ -45,7 +45,7 @@ contract CometFlexVoting is Comet, FlexVotingClient {
     FlexVotingClient.totalDepositCheckpoints.push(uint224(totalSupplyBase));
   }
   //
-  //===========================================================================
+//===========================================================================
   // END: Comet overrides
   //===========================================================================
   // forgefmt: disable-end

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -37,7 +37,7 @@ contract CometFlexVoting is Comet, FlexVotingClient {
   {
     Comet.updateBasePrincipal(_account, _userBasic, _principalNew);
     FlexVotingClient._checkpointRawBalanceOf(_account);
-    FlexVotingClient.totalDepositCheckpoints.push(uint224(totalSupplyBase));
+    FlexVotingClient.totalBalanceCheckpoints.push(uint224(totalSupplyBase));
   }
   //===========================================================================
   // END: Comet overrides

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -54,6 +54,10 @@ contract CometFlexVoting is Comet, FlexVotingClient {
     return _principal > 0 ? uint256(int256(_principal)) : 0;
   }
 
+  function _castVoteReasonString() internal override returns (string memory) {
+    return "rolled-up vote from CometFlexVoting token holders";
+  }
+
   //===========================================================================
   // BEGIN: Comet overrides
   //===========================================================================

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -13,9 +13,9 @@ import {FlexVotingClient} from "src/FlexVotingClient.sol";
 /// yield on Compound and voting. They can do both.
 ///
 /// This extension has the following requirements:
-///   (a) the base token be a governance token
-///   (b) the base token's governor contract support flexible voting (see
-///       GovernorCountingFractional)
+///   (a) The base token must be a governance token.
+///   (b) The base token's governor contract must support flexible voting (see
+///       `GovernorCountingFractional`).
 ///
 /// If these requirements are met, base token depositors can call
 /// `Comet.expressVote` to signal their preference on open governance proposals.

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -34,28 +34,15 @@ contract CometFlexVoting is Comet, FlexVotingClient {
   // BEGIN: Comet overrides
   //===========================================================================
   //
-  // This function is called anytime the underlying balance is changed.
+  // This function is called any time the underlying balance is changed.
   function updateBasePrincipal(
     address _account,
     UserBasic memory _userBasic,
     int104 _principalNew
   ) internal override {
-    int104 _principalInitial = userBasic[_account].principal;
-    int224 _initTotalDeposits = int224(FlexVotingClient.totalDepositCheckpoints.latest());
-
     Comet.updateBasePrincipal(_account, _userBasic, _principalNew);
-
-    // Checkpoint the account's balance.
     FlexVotingClient._checkpointRawBalanceOf(_account);
-
-    // TODO why not just do:
-    // baseToken.balanceOf(address(this)) ?
-
-    // Checkpoint the pool's total balance.
-    int104 _principalDelta = _principalNew - _principalInitial;
-    int224 _newTotalDeposits = _initTotalDeposits + _principalDelta;
-    // TODO Can _newTotalDeposits ever go negative?
-    FlexVotingClient.totalDepositCheckpoints.push(uint224(_newTotalDeposits));
+    FlexVotingClient.totalDepositCheckpoints.push(uint224(totalSupplyBase));
   }
   //
   //===========================================================================

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -13,7 +13,6 @@ import {FlexVotingClient} from "src/FlexVotingClient.sol";
 contract CometFlexVoting is Comet, FlexVotingClient {
   using Checkpoints for Checkpoints.History;
 
-  /// @dev Constructor.
   /// @param _config The configuration struct for this Comet instance.
   /// @param _governor The address of the flex-voting-compatible governance contract.
   constructor(CometConfiguration.Configuration memory _config, address _governor)
@@ -23,7 +22,7 @@ contract CometFlexVoting is Comet, FlexVotingClient {
     selfDelegate();
   }
 
-  /// @notice Returns the _user's current balance in storage.
+  /// @notice Returns the current balance in storage for the `account`.
   function _rawBalanceOf(address account) internal view override returns (uint256) {
     int104 _principal = userBasic[account].principal;
     return _principal > 0 ? uint256(int256(_principal)) : 0;
@@ -34,7 +33,7 @@ contract CometFlexVoting is Comet, FlexVotingClient {
   // BEGIN: Comet overrides
   //===========================================================================
   //
-// This function is called any time the underlying balance is changed.
+  // This function is called any time the underlying balance is changed.
   function updateBasePrincipal(
     address _account,
     UserBasic memory _userBasic,
@@ -45,7 +44,7 @@ contract CometFlexVoting is Comet, FlexVotingClient {
     FlexVotingClient.totalDepositCheckpoints.push(uint224(totalSupplyBase));
   }
   //
-//===========================================================================
+  //===========================================================================
   // END: Comet overrides
   //===========================================================================
   // forgefmt: disable-end

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10;
+
+import { Comet } from "comet/Comet.sol";
+import { CometConfiguration } from "comet/CometConfiguration.sol";
+
+import {IVotingToken} from "src/interfaces/IVotingToken.sol";
+import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
+
+// TODO add description
+contract CometFlexVoting is Comet {
+  /// @notice The governor contract associated with this contract's baseToken. It
+  /// must be one that supports fractional voting, e.g. GovernorCountingFractional.
+  IFractionalGovernor public immutable GOVERNOR;
+
+  /// @dev Constructor.
+  /// @param _config The configuration struct for this Comet instance.
+  /// @param _governor The address of the flex-voting-compatible governance contract.
+  constructor(
+    CometConfiguration.Configuration memory _config,
+    address _governor
+  ) Comet(_config) {
+    GOVERNOR = IFractionalGovernor(_governor);
+    selfDelegate();
+  }
+
+  // This is called within the constructor, but we want it to be publically
+  // available if/when existing cTokens are upgraded.
+  // TODO can cTokens be upgraded?
+  function selfDelegate() public {
+    IVotingToken(GOVERNOR.token()).delegate(address(this));
+  }
+
+  // forgefmt: disable-start
+  //===========================================================================
+  // BEGIN: Comet overrides
+  //===========================================================================
+  //===========================================================================
+  // END: Comet overrides
+  //===========================================================================
+  // forgefmt: disable-end
+}

--- a/src/CometFlexVoting.sol
+++ b/src/CometFlexVoting.sol
@@ -5,8 +5,6 @@ import {Comet} from "comet/Comet.sol";
 import {CometConfiguration} from "comet/CometConfiguration.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
 
-import {IVotingToken} from "src/interfaces/IVotingToken.sol";
-import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
 import {FlexVotingClient} from "src/FlexVotingClient.sol";
 
 // TODO add description
@@ -19,7 +17,7 @@ contract CometFlexVoting is Comet, FlexVotingClient {
     Comet(_config)
     FlexVotingClient(_governor)
   {
-    selfDelegate();
+    _selfDelegate();
   }
 
   /// @notice Returns the current balance in storage for the `account`.
@@ -28,24 +26,20 @@ contract CometFlexVoting is Comet, FlexVotingClient {
     return _principal > 0 ? uint256(int256(_principal)) : 0;
   }
 
-  // forgefmt: disable-start
   //===========================================================================
   // BEGIN: Comet overrides
   //===========================================================================
   //
   // This function is called any time the underlying balance is changed.
-  function updateBasePrincipal(
-    address _account,
-    UserBasic memory _userBasic,
-    int104 _principalNew
-  ) internal override {
+  function updateBasePrincipal(address _account, UserBasic memory _userBasic, int104 _principalNew)
+    internal
+    override
+  {
     Comet.updateBasePrincipal(_account, _userBasic, _principalNew);
     FlexVotingClient._checkpointRawBalanceOf(_account);
     FlexVotingClient.totalDepositCheckpoints.push(uint224(totalSupplyBase));
   }
-  //
   //===========================================================================
   // END: Comet overrides
   //===========================================================================
-  // forgefmt: disable-end
 }

--- a/src/FlexVotingClient.sol
+++ b/src/FlexVotingClient.sol
@@ -38,11 +38,13 @@ import {IVotingToken} from "src/interfaces/IVotingToken.sol";
 /// deposit amounts are scaled down by an ever-increasing index that represents
 /// the cumulative amount of interest earned over the lifetime of deposits. The
 /// "raw balance" of a user in Aave's case is this scaled down amount, since it
-/// is the value that represents the user's claim on deposits.
+/// is the value that represents the user's claim on deposits. Thus for Aave, a
+/// users's raw balance will always be less than the actual amount they have
+/// claim to.
 ///
 /// If the raw balance can be identified and defined for a system, and
-/// `_rawBalance` implemented for it, then this contract will take care of the
-/// rest.
+/// `_rawBalance` can be implemented for it, then this contract will take care
+/// of the rest.
 abstract contract FlexVotingClient {
   using SafeCast for uint256;
   using Checkpoints for Checkpoints.History;
@@ -61,7 +63,7 @@ abstract contract FlexVotingClient {
     uint128 abstainVotes;
   }
 
-  /// @notice Map proposalId to an address to whether they have voted on this proposal.
+  /// @dev Map proposalId to an address to whether they have voted on this proposal.
   mapping(uint256 => mapping(address => bool)) private proposalVotersHasVoted;
 
   /// @notice Map proposalId to vote totals expressed on this proposal.
@@ -71,11 +73,11 @@ abstract contract FlexVotingClient {
   /// must be one that supports fractional voting, e.g. GovernorCountingFractional.
   IFractionalGovernor public immutable GOVERNOR;
 
-  /// @notice Mapping from address to the checkpoint history of raw balances
+  /// @dev Mapping from address to the checkpoint history of raw balances
   /// of that address.
   mapping(address => Checkpoints.History) private balanceCheckpoints;
 
-  /// @notice History of the sum total of raw balances in the system. May or may
+  /// @dev History of the sum total of raw balances in the system. May or may
   /// not be equivalent to this contract's balance of `GOVERNOR`s token at a
   /// given time.
   Checkpoints.History internal totalBalanceCheckpoints;
@@ -85,13 +87,13 @@ abstract contract FlexVotingClient {
     GOVERNOR = IFractionalGovernor(_governor);
   }
 
-  /// @notice Returns a representation of the current amount of `GOVERNOR`s
+  /// @dev Returns a representation of the current amount of `GOVERNOR`s
   /// token that `_user` has claim to in this system. It may or may not be
   /// equivalent to the withdrawable balance of `GOVERNOR`s token for `user`,
   /// e.g. if the internal representation of balance has been scaled down.
   function _rawBalanceOf(address _user) internal view virtual returns (uint256);
 
-  /// @notice Delegates the present contract's voting rights with `GOVERNOR` to itself.
+  /// @dev Delegates the present contract's voting rights with `GOVERNOR` to itself.
   function _selfDelegate() internal {
     IVotingToken(GOVERNOR.token()).delegate(address(this));
   }
@@ -187,7 +189,7 @@ abstract contract FlexVotingClient {
     );
   }
 
-  /// @notice Checkpoints the _user's current raw balance.
+  /// @dev Checkpoints the _user's current raw balance.
   function _checkpointRawBalanceOf(address _user) internal {
     balanceCheckpoints[_user].push(_rawBalanceOf(_user));
   }

--- a/src/FlexVotingClient.sol
+++ b/src/FlexVotingClient.sol
@@ -48,8 +48,9 @@ abstract contract FlexVotingClient {
     GOVERNOR = IFractionalGovernor(_governor);
   }
 
-  // TODO Child contracts must implement these functions.
-  /// @notice Returns the _user's current balance in storage.
+  /// @notice Returns the _user's current balance in storage. If the balance is
+  /// rebasing this should return the non-rebased value, i.e. the value before
+  /// any computations are run or interest is applied.
   function _rawBalanceOf(address _user) internal view virtual returns (uint256);
 
   // TODO add natspec

--- a/src/FlexVotingClient.sol
+++ b/src/FlexVotingClient.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10;
+
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
+import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
+import {IVotingToken} from "src/interfaces/IVotingToken.sol";
+
+// TODO natspec
+// this is a contract to make it easy to build clients for flex voting governors.
+abstract contract FlexVotingClient {
+  using SafeCast for uint256;
+  using Checkpoints for Checkpoints.History;
+
+  /// @notice The voting options corresponding to those used in the Governor.
+  enum VoteType {
+    Against,
+    For,
+    Abstain
+  }
+
+  /// @notice Data structure to store vote preferences expressed by depositors.
+  struct ProposalVote {
+    uint128 againstVotes;
+    uint128 forVotes;
+    uint128 abstainVotes;
+  }
+
+  /// @notice Map proposalId to an address to whether they have voted on this proposal.
+  mapping(uint256 => mapping(address => bool)) private proposalVotersHasVoted;
+
+  /// @notice Map proposalId to vote totals expressed on this proposal.
+  mapping(uint256 => ProposalVote) public proposalVotes;
+
+  /// @notice The governor contract associated with this governance token. It
+  /// must be one that supports fractional voting, e.g. GovernorCountingFractional.
+  IFractionalGovernor public immutable GOVERNOR;
+
+  /// @notice Mapping from address to stored (not rebased) balance checkpoint history.
+  mapping(address => Checkpoints.History) private balanceCheckpoints;
+
+  /// @notice History of total stored (not rebased) balances.
+  Checkpoints.History internal totalDepositCheckpoints;
+
+  /// @dev Constructor.
+  /// @param _governor The address of the flex-voting-compatible governance contract.
+  constructor(address _governor) {
+    GOVERNOR = IFractionalGovernor(_governor);
+  }
+
+  // TODO Child contracts must implement these functions.
+  /// @notice Returns the _user's current balance in storage.
+  function _rawBalanceOf(address _user) internal view virtual returns (uint256);
+
+  // TODO add natspec
+  function selfDelegate() public {
+    IVotingToken(GOVERNOR.token()).delegate(address(this));
+  }
+
+  /// @notice Allow a depositor to express their voting preference for a given
+  /// proposal. Their preference is recorded internally but not moved to the
+  /// Governor until `castVote` is called.
+  /// @param proposalId The proposalId in the associated Governor
+  /// @param support The depositor's vote preferences in accordance with the `VoteType` enum.
+  function expressVote(uint256 proposalId, uint8 support) external {
+    uint256 weight = getPastStoredBalance(msg.sender, GOVERNOR.proposalSnapshot(proposalId));
+    require(weight > 0, "no weight");
+
+    require(!proposalVotersHasVoted[proposalId][msg.sender], "already voted");
+    proposalVotersHasVoted[proposalId][msg.sender] = true;
+
+    if (support == uint8(VoteType.Against)) {
+      proposalVotes[proposalId].againstVotes += SafeCast.toUint128(weight);
+    } else if (support == uint8(VoteType.For)) {
+      proposalVotes[proposalId].forVotes += SafeCast.toUint128(weight);
+    } else if (support == uint8(VoteType.Abstain)) {
+      proposalVotes[proposalId].abstainVotes += SafeCast.toUint128(weight);
+    } else {
+      revert("invalid support value, must be included in VoteType enum");
+    }
+  }
+
+  /// @notice Causes this contract to cast a vote to the Governor for all of the
+  /// accumulated votes expressed by users. Uses the sum of all raw (unrebased) balances
+  /// to proportionally split its voting weight. Can be called by anyone. Can be called
+  /// multiple times during the lifecycle of a given proposal.
+  /// @param proposalId The ID of the proposal which the Pool will now vote on.
+  function castVote(uint256 proposalId) external {
+    ProposalVote storage _proposalVote = proposalVotes[proposalId];
+    require(
+      _proposalVote.forVotes + _proposalVote.againstVotes + _proposalVote.abstainVotes > 0,
+      "no votes expressed"
+    );
+    uint256 _proposalSnapshotBlockNumber = GOVERNOR.proposalSnapshot(proposalId);
+
+    // We use the snapshot of total raw balances to determine the weight with
+    // which to vote. We do this for two reasons:
+    //   (1) We cannot use the proposalVote numbers alone, since some people with
+    //       balances at the snapshot might never express their preferences. If a
+    //       large holder never expressed a preference, but this contract nevertheless
+    //       cast votes to the governor with all of its weight, then other users may
+    //       effectively have *increased* their voting weight because someone else
+    //       didn't participate, which creates all kinds of bad incentives.
+    //   (2) Other people might have already expressed their preferences on this
+    //       proposal and had those preferences submitted to the governor by an
+    //       earlier call to this function. The weight of those preferences
+    //       should still be taken into consideration when determining how much
+    //       weight to vote with this time.
+    // Using the total raw balance to proportion votes in this way means that in
+    // many circumstances this function will not cast votes with all of its
+    // weight.
+    uint256 _totalRawBalanceAtSnapshot = getPastTotalBalance(_proposalSnapshotBlockNumber);
+
+    // We need 256 bits because of the multiplication we're about to do.
+    uint256 _votingWeightAtSnapshot = IVotingToken(address(GOVERNOR.token())).getPastVotes(
+      address(this), _proposalSnapshotBlockNumber
+    );
+
+    //      forVotesRaw          forVoteWeight
+    // --------------------- = ------------------
+    //     totalRawBalance      totalVoteWeight
+    //
+    // forVoteWeight = forVotesRaw * totalVoteWeight / totalRawBalance
+    uint128 _forVotesToCast = SafeCast.toUint128(
+      (_votingWeightAtSnapshot * _proposalVote.forVotes) / _totalRawBalanceAtSnapshot
+    );
+    uint128 _againstVotesToCast = SafeCast.toUint128(
+      (_votingWeightAtSnapshot * _proposalVote.againstVotes) / _totalRawBalanceAtSnapshot
+    );
+    uint128 _abstainVotesToCast = SafeCast.toUint128(
+      (_votingWeightAtSnapshot * _proposalVote.abstainVotes) / _totalRawBalanceAtSnapshot
+    );
+
+    // This param is ignored by the governor when voting with fractional
+    // weights. It makes no difference what vote type this is.
+    uint8 unusedSupportParam = uint8(VoteType.Abstain);
+
+    // Clear the stored votes so that we don't double-cast them.
+    delete proposalVotes[proposalId];
+
+    bytes memory fractionalizedVotes =
+      abi.encodePacked(_againstVotesToCast, _forVotesToCast, _abstainVotesToCast);
+    GOVERNOR.castVoteWithReasonAndParams(
+      proposalId,
+      unusedSupportParam,
+      "rolled-up vote from governance token holders", // Reason string.
+      fractionalizedVotes
+    );
+  }
+
+  /// @notice Checkpoints the _user's current raw balance.
+  function _checkpointRawBalanceOf(address _user) internal {
+    balanceCheckpoints[_user].push(_rawBalanceOf(_user));
+  }
+
+  /// @notice Returns the _user's balance in storage at the _blockNumber.
+  /// @param _user The account that's historical balance will be looked up.
+  /// @param _blockNumber The block at which to lookup the _user's balance.
+  function getPastStoredBalance(address _user, uint256 _blockNumber) public view returns (uint256) {
+    return balanceCheckpoints[_user].getAtProbablyRecentBlock(_blockNumber);
+  }
+
+  /// @notice Returns the total stored balance of all users at _blockNumber.
+  /// @param _blockNumber The block at which to lookup the total stored balance.
+  function getPastTotalBalance(uint256 _blockNumber) public view returns (uint256) {
+    return totalDepositCheckpoints.getAtProbablyRecentBlock(_blockNumber);
+  }
+}

--- a/src/FlexVotingClient.sol
+++ b/src/FlexVotingClient.sol
@@ -48,8 +48,8 @@ abstract contract FlexVotingClient {
     GOVERNOR = IFractionalGovernor(_governor);
   }
 
-  /// @notice Returns the _user's current balance in storage. If the balance is
-  /// rebasing this should return the non-rebased value, i.e. the value before
+  /// @notice Returns the _user's current balance in storage. If the balance
+  /// rebases this should return the non-rebased value, i.e. the value before
   /// any computations are run or interest is applied.
   function _rawBalanceOf(address _user) internal view virtual returns (uint256);
 

--- a/src/FlexVotingClient.sol
+++ b/src/FlexVotingClient.sol
@@ -93,6 +93,11 @@ abstract contract FlexVotingClient {
   /// e.g. if the internal representation of balance has been scaled down.
   function _rawBalanceOf(address _user) internal view virtual returns (uint256);
 
+  /// @dev Used as the `reason` param when submitting a vote to `GOVERNOR`.
+  function _castVoteReasonString() internal virtual returns (string memory) {
+    return "rolled-up vote from governance token holders";
+  }
+
   /// @dev Delegates the present contract's voting rights with `GOVERNOR` to itself.
   function _selfDelegate() internal {
     IVotingToken(GOVERNOR.token()).delegate(address(this));
@@ -182,10 +187,7 @@ abstract contract FlexVotingClient {
     bytes memory fractionalizedVotes =
       abi.encodePacked(_againstVotesToCast, _forVotesToCast, _abstainVotesToCast);
     GOVERNOR.castVoteWithReasonAndParams(
-      proposalId,
-      unusedSupportParam,
-      "rolled-up vote from governance token holders", // Reason string.
-      fractionalizedVotes
+      proposalId, unusedSupportParam, _castVoteReasonString(), fractionalizedVotes
     );
   }
 

--- a/src/FlexVotingClient.sol
+++ b/src/FlexVotingClient.sol
@@ -54,7 +54,7 @@ abstract contract FlexVotingClient {
   function _rawBalanceOf(address _user) internal view virtual returns (uint256);
 
   // TODO add natspec
-  function selfDelegate() public {
+  function _selfDelegate() internal {
     IVotingToken(GOVERNOR.token()).delegate(address(this));
   }
 

--- a/src/interfaces/IFractionalGovernor.sol
+++ b/src/interfaces/IFractionalGovernor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.10;
+pragma solidity >=0.8.10;
 
 /// @dev The interface that flexible voting-compatbile governors are expected to support.
 interface IFractionalGovernor {

--- a/src/interfaces/IFractionalGovernor.sol
+++ b/src/interfaces/IFractionalGovernor.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.10;
 
-/// @dev The interface that flexible voting-compatbile governors are expected to support.
+/// @dev The interface that flexible voting-compatible governors are expected to support.
 interface IFractionalGovernor {
   function token() external returns (address);
   function proposalSnapshot(uint256 proposalId) external view returns (uint256);

--- a/src/interfaces/IVotingToken.sol
+++ b/src/interfaces/IVotingToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.10;
+pragma solidity >=0.8.10;
 
 /// @dev The interface that flexible voting-compatible voting tokens are expected to support.
 interface IVotingToken {

--- a/test/ATokenFlexVotingFork.t.sol
+++ b/test/ATokenFlexVotingFork.t.sol
@@ -1663,7 +1663,7 @@ contract CastVote is AaveAtokenForkTest {
   }
 }
 
-contract GetPastStoredBalanceTest is AaveAtokenForkTest {
+contract GetPastRawBalanceTest is AaveAtokenForkTest {
   function test_GetPastStoredBalanceCorrectlyReadsCheckpoints() public {
     _initiateRebasing();
 
@@ -1696,17 +1696,17 @@ contract GetPastStoredBalanceTest is AaveAtokenForkTest {
     vm.roll(block.number + _blocksJumped);
     vm.warp(block.timestamp + 42 days);
 
-    // getPastStoredBalance should match the initial raw balance.
+    // getPastRawBalance should match the initial raw balance.
     assertEq(
-      aToken.getPastStoredBalance(_who, block.number - _blocksJumped + 1),
+      aToken.getPastRawBalance(_who, block.number - _blocksJumped + 1),
       _rawBalances[0],
-      "getPastStoredBalance does not match the initial raw balance"
+      "getPastRawBalance does not match the initial raw balance"
     );
 
-    // getPastStoredBalance should be able to give us the raw balance at an
+    // getPastRawBalance should be able to give us the raw balance at an
     // intermediate point.
     assertEq(
-      aToken.getPastStoredBalance(
+      aToken.getPastRawBalance(
         _who,
         block.number - (_blocksJumped / 3) // 1/3 is just an arbitrary point.
       ),
@@ -1725,28 +1725,28 @@ contract GetPastStoredBalanceTest is AaveAtokenForkTest {
     // Rebasing should not affect the raw balance.
     assertGt(_rawBalances[1], _rawBalances[0], "raw balance did not increase");
 
-    // getPastStoredBalance should match historical balances.
+    // getPastRawBalance should match historical balances.
     assertEq(
-      aToken.getPastStoredBalance(_who, block.number - _blocksJumped - _blocksJumpedSecondTime + 1),
+      aToken.getPastRawBalance(_who, block.number - _blocksJumped - _blocksJumpedSecondTime + 1),
       _rawBalances[0],
-      "getPastStoredBalance did not match original raw balance"
+      "getPastRawBalance did not match original raw balance"
     );
     assertEq(
-      aToken.getPastStoredBalance(_who, block.number - _blocksJumpedSecondTime + 1),
+      aToken.getPastRawBalance(_who, block.number - _blocksJumpedSecondTime + 1),
       _rawBalances[1],
-      "getPastStoredBalance did not match raw balance after second supply"
+      "getPastRawBalance did not match raw balance after second supply"
     );
-    // getPastStoredBalance should be able to give us the raw balance at intermediate points.
+    // getPastRawBalance should be able to give us the raw balance at intermediate points.
     assertEq(
-      aToken.getPastStoredBalance(_who, block.number - _blocksJumpedSecondTime / 3), // random point
+      aToken.getPastRawBalance(_who, block.number - _blocksJumpedSecondTime / 3), // random point
       _rawBalances[1]
     );
     assertEq(
-      aToken.getPastStoredBalance(_who, block.number - _blocksJumpedSecondTime / 3),
-      aToken.getPastStoredBalance(_who, block.number - 1)
+      aToken.getPastRawBalance(_who, block.number - _blocksJumpedSecondTime / 3),
+      aToken.getPastRawBalance(_who, block.number - 1)
     );
 
-    // Withdrawals should be reflected in getPastStoredBalance.
+    // Withdrawals should be reflected in getPastRawBalance.
     vm.startPrank(_who);
     pool.withdraw(
       address(govToken),
@@ -1761,13 +1761,13 @@ contract GetPastStoredBalanceTest is AaveAtokenForkTest {
     vm.warp(block.timestamp + 10 days);
 
     assertEq(
-      aToken.getPastStoredBalance(_who, block.number - _blocksJumpedThirdTime),
+      aToken.getPastRawBalance(_who, block.number - _blocksJumpedThirdTime),
       aToken.exposed_RawBalanceOf(_who)
     );
-    assertEq(aToken.getPastStoredBalance(_who, block.number - 1), aToken.exposed_RawBalanceOf(_who));
+    assertEq(aToken.getPastRawBalance(_who, block.number - 1), aToken.exposed_RawBalanceOf(_who));
     assertGt(
       _rawBalances[1], // The raw balance pre-withdrawal.
-      aToken.getPastStoredBalance(_who, block.number - _blocksJumpedThirdTime)
+      aToken.getPastRawBalance(_who, block.number - _blocksJumpedThirdTime)
     );
   }
 
@@ -1804,11 +1804,11 @@ contract GetPastStoredBalanceTest is AaveAtokenForkTest {
 
     // Confirm voting weight has shifted.
     assertEq(
-      aToken.getPastStoredBalance(_userA, block.number - 1),
+      aToken.getPastRawBalance(_userA, block.number - 1),
       2 * _initRawBalanceUserA / 3 // 2/3rds of A's initial balance
     );
     assertEq(
-      aToken.getPastStoredBalance(_userB, block.number - 1),
+      aToken.getPastRawBalance(_userB, block.number - 1),
       1 * _initRawBalanceUserA / 3 // 1/3rd of A's initial balance
     );
   }
@@ -1847,11 +1847,11 @@ contract GetPastStoredBalanceTest is AaveAtokenForkTest {
 
     // Confirm voting weight has shifted.
     assertEq(
-      aToken.getPastStoredBalance(_userA, block.number - 1),
+      aToken.getPastRawBalance(_userA, block.number - 1),
       2 * _initRawBalanceUserA / 3 // 2/3rds of A's initial balance
     );
     assertEq(
-      aToken.getPastStoredBalance(_userB, block.number - 1),
+      aToken.getPastRawBalance(_userB, block.number - 1),
       1 * _initRawBalanceUserA / 3 // 1/3rd of A's initial balance
     );
   }
@@ -1887,7 +1887,7 @@ contract GetPastStoredBalanceTest is AaveAtokenForkTest {
 
     assertGt(aToken.balanceOf(_treasury), _initTreasuryBalance);
 
-    assertGt(aToken.getPastStoredBalance(_treasury, block.number - 1), 0);
+    assertGt(aToken.getPastRawBalance(_treasury, block.number - 1), 0);
   }
 }
 

--- a/test/CometFlexVotingFork.t.sol
+++ b/test/CometFlexVotingFork.t.sol
@@ -1047,21 +1047,3 @@ contract CastVote is CometForkTest {
     if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _voteWeightA);
   }
 }
-
-// TODO
-// From https://docs.compound.finance/collateral-and-borrowing/
-//   Account balances for the base token are signed integers. An account balance
-//   greater than zero indicates the base asset is supplied and A BALANCE LESS
-//   THAN ZERO INDICATES THE BASE ASSET IS BORROWED (emphasis mine)
-// What happens if someone tries to expressVote when they have borrowed the base
-// asset? We need to make sure that they cannot.
-// This should be fine because the FlexVotingClient.expressVote function checks
-// that getPastStoredBalance > 0 and reverts otherwise. But we should have a
-// test to confirm.
-
-// TODO
-// If we want to be really thorough we should test that each of the cToken
-// supply/withdraw functions modifies the internal cToken checkpointing properly
-//
-// TODO
-// Test that people who supply collateral cannot express votes.

--- a/test/CometFlexVotingFork.t.sol
+++ b/test/CometFlexVotingFork.t.sol
@@ -70,75 +70,75 @@ contract CometForkTest is Test, CometConfiguration {
     // These configs are all based on the cUSDCv3 token configs:
     //   https://etherscan.io/address/0xc3d688B66703497DAA19211EEdff47f25384cdc3#readProxyContract
     AssetConfig[] memory _assetConfigs = new AssetConfig[](5);
-    _assetConfigs[0] = AssetConfig(
+    _assetConfigs[0] = AssetConfig({
       asset: 0xc00e94Cb662C3520282E6f5717214004A7f26888, // COMP
       priceFeed: 0xdbd020CAeF83eFd542f4De03e3cF0C28A4428bd5,
       decimals: 18,
-      borrowCollateralFactor: 650_000_000_000_000_000, 
+      borrowCollateralFactor: 650_000_000_000_000_000,
       liquidateCollateralFactor: 700_000_000_000_000_000,
       liquidationFactor: 880_000_000_000_000_000,
       supplyCap: 900_000_000_000_000_000_000_000
-    );
-    _assetConfigs[1] = AssetConfig(
-      0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599, // asset, WBTC
-      0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c, // priceFeed
-      8, // decimals
-      700_000_000_000_000_000, // borrowCollateralFactor
-      770_000_000_000_000_000, // liquidateCollateralFactor
-      950_000_000_000_000_000, // liquidationFactor
-      1_200_000_000_000 // supplyCap
-    );
-    _assetConfigs[2] = AssetConfig(
-      weth, // asset
-      0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419, // priceFeed
-      18, // decimals
-      825_000_000_000_000_000, // borrowCollateralFactor
-      895_000_000_000_000_000, // liquidateCollateralFactor
-      950_000_000_000_000_000, // liquidationFactor
-      350_000_000_000_000_000_000_000 // supplyCap
-    );
-    _assetConfigs[3] = AssetConfig(
-      0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, // asset, UNI
-      0x553303d460EE0afB37EdFf9bE42922D8FF63220e, // priceFeed
-      18, // decimals
-      750_000_000_000_000_000, // borrowCollateralFactor
-      810_000_000_000_000_000, // liquidateCollateralFactor
-      930_000_000_000_000_000, // liquidationFactor
-      2_300_000_000_000_000_000_000_000 // supplyCap
-    );
-    _assetConfigs[4] = AssetConfig(
-      0x514910771AF9Ca656af840dff83E8264EcF986CA, // asset, LINK
-      0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c, // priceFeed
-      18, // decimals
-      790_000_000_000_000_000, // borrowCollateralFactor
-      850_000_000_000_000_000, // liquidateCollateralFactor
-      930_000_000_000_000_000, // liquidationFactor
-      1_250_000_000_000_000_000_000_000 // supplyCap
-    );
-    Configuration memory _config = Configuration(
-      COMPOUND_GOVERNOR,
-      0xbbf3f1421D886E9b2c5D716B5192aC998af2012c, // pauseGuardian
-      address(govToken), // baseToken
-      0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6, // baseTokenPriceFeed, using the chainlink
-        // USDC/USD price feed
-      0x285617313887d43256F852cAE0Ee4de4b68D45B0, // extensionDelegate
-      800_000_000_000_000_000, // supplyKink
-      1_030_568_239 * 60 * 60 * 24 * 365, // supplyPerYearInterestRateSlopeLow
-      12_683_916_793 * 60 * 60 * 24 * 365, // supplyPerYearInterestRateSlopeHigh
-      0, // supplyPerYearInterestRateBase
-      800_000_000_000_000_000, // borrowKink
-      1_109_842_719 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateSlopeLow
-      7_927_447_995 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateSlopeHigh
-      475_646_879 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateBase
-      600_000_000_000_000_000, // storeFrontPriceFactor
-      1_000_000_000_000_000, // trackingIndexScale
-      0, // baseTrackingSupplySpeed
-      3_257_060_185_185, // baseTrackingBorrowSpeed
-      1_000_000_000_000, // baseMinForRewards
-      100_000_000, // baseBorrowMin
-      5_000_000_000_000, // targetReserves
-      _assetConfigs
-    );
+    });
+    _assetConfigs[1] = AssetConfig({
+      asset: 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599, // WBTC
+      priceFeed: 0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c,
+      decimals: 8,
+      borrowCollateralFactor: 700_000_000_000_000_000,
+      liquidateCollateralFactor: 770_000_000_000_000_000,
+      liquidationFactor: 950_000_000_000_000_000,
+      supplyCap: 1_200_000_000_000
+    });
+    _assetConfigs[2] = AssetConfig({
+      asset: weth,
+      priceFeed: 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419,
+      decimals: 18,
+      borrowCollateralFactor: 825_000_000_000_000_000,
+      liquidateCollateralFactor: 895_000_000_000_000_000,
+      liquidationFactor: 950_000_000_000_000_000,
+      supplyCap: 350_000_000_000_000_000_000_000
+    });
+    _assetConfigs[3] = AssetConfig({
+      asset: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984,
+      priceFeed: 0x553303d460EE0afB37EdFf9bE42922D8FF63220e,
+      decimals: 18,
+      borrowCollateralFactor: 750_000_000_000_000_000,
+      liquidateCollateralFactor: 810_000_000_000_000_000,
+      liquidationFactor: 930_000_000_000_000_000,
+      supplyCap: 2_300_000_000_000_000_000_000_000
+    });
+    _assetConfigs[4] = AssetConfig({
+      asset: 0x514910771AF9Ca656af840dff83E8264EcF986CA,
+      priceFeed: 0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c,
+      decimals: 18,
+      borrowCollateralFactor: 790_000_000_000_000_000,
+      liquidateCollateralFactor: 850_000_000_000_000_000,
+      liquidationFactor: 930_000_000_000_000_000,
+      supplyCap: 1_250_000_000_000_000_000_000_000
+    });
+    address _chainlinkUsdcUsdFeed = 0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6;
+    Configuration memory _config = Configuration({
+      governor: COMPOUND_GOVERNOR,
+      pauseGuardian: 0xbbf3f1421D886E9b2c5D716B5192aC998af2012c,
+      baseToken: address(govToken),
+      baseTokenPriceFeed: _chainlinkUsdcUsdFeed,
+      extensionDelegate: 0x285617313887d43256F852cAE0Ee4de4b68D45B0,
+      supplyKink: 800_000_000_000_000_000,
+      supplyPerYearInterestRateSlopeLow: 1_030_568_239 * 60 * 60 * 24 * 365,
+      supplyPerYearInterestRateSlopeHigh: 12_683_916_793 * 60 * 60 * 24 * 365,
+      supplyPerYearInterestRateBase: 0,
+      borrowKink: 800_000_000_000_000_000,
+      borrowPerYearInterestRateSlopeLow: 1_109_842_719 * 60 * 60 * 24 * 365,
+      borrowPerYearInterestRateSlopeHigh: 7_927_447_995 * 60 * 60 * 24 * 365,
+      borrowPerYearInterestRateBase: 475_646_879 * 60 * 60 * 24 * 365,
+      storeFrontPriceFactor: 600_000_000_000_000_000,
+      trackingIndexScale: 1_000_000_000_000_000,
+      baseTrackingSupplySpeed: 0,
+      baseTrackingBorrowSpeed: 3_257_060_185_185,
+      baseMinForRewards: 1_000_000_000_000,
+      baseBorrowMin: 100_000_000,
+      targetReserves: 5_000_000_000_000,
+      assetConfigs: _assetConfigs
+    });
 
     cToken = new CometFlexVoting(_config, address(flexVotingGovernor));
 

--- a/test/CometFlexVotingFork.t.sol
+++ b/test/CometFlexVotingFork.t.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity >=0.8.10;
 
-import { Test } from "forge-std/Test.sol";
-import { Vm } from "forge-std/Vm.sol";
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 import "forge-std/console2.sol";
 
-import { IVotes } from "@openzeppelin/contracts/governance/utils/IVotes.sol";
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-import { CometFlexVoting } from "src/CometFlexVoting.sol";
-import { FractionalGovernor } from "test/FractionalGovernor.sol";
-import { ProposalReceiverMock } from "test/ProposalReceiverMock.sol";
-import { GovToken } from "test/GovToken.sol";
+import {CometFlexVoting} from "src/CometFlexVoting.sol";
+import {FractionalGovernor} from "test/FractionalGovernor.sol";
+import {ProposalReceiverMock} from "test/ProposalReceiverMock.sol";
+import {GovToken} from "test/GovToken.sol";
 
-import { CometConfiguration } from "comet/CometConfiguration.sol";
-import { Comet } from "comet/Comet.sol";
+import {CometConfiguration} from "comet/CometConfiguration.sol";
+import {Comet} from "comet/Comet.sol";
 
 contract CometForkTest is Test, CometConfiguration {
   uint256 forkId;
@@ -76,68 +76,69 @@ contract CometForkTest is Test, CometConfiguration {
       0xc00e94Cb662C3520282E6f5717214004A7f26888, // asset, COMP
       0xdbd020CAeF83eFd542f4De03e3cF0C28A4428bd5, // priceFeed
       18, // decimals
-      650000000000000000, // borrowCollateralFactor
-      700000000000000000, // liquidateCollateralFactor
-      880000000000000000, // liquidationFactor
-      900000000000000000000000 // supplyCap
+      650_000_000_000_000_000, // borrowCollateralFactor
+      700_000_000_000_000_000, // liquidateCollateralFactor
+      880_000_000_000_000_000, // liquidationFactor
+      900_000_000_000_000_000_000_000 // supplyCap
     );
     _assetConfigs[1] = AssetConfig(
       0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599, // asset, WBTC
       0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c, // priceFeed
       8, // decimals
-      700000000000000000, // borrowCollateralFactor
-      770000000000000000, // liquidateCollateralFactor
-      950000000000000000, // liquidationFactor
-      1200000000000 // supplyCap
+      700_000_000_000_000_000, // borrowCollateralFactor
+      770_000_000_000_000_000, // liquidateCollateralFactor
+      950_000_000_000_000_000, // liquidationFactor
+      1_200_000_000_000 // supplyCap
     );
     _assetConfigs[2] = AssetConfig(
       weth, // asset
       0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419, // priceFeed
       18, // decimals
-      825000000000000000, // borrowCollateralFactor
-      895000000000000000, // liquidateCollateralFactor
-      950000000000000000, // liquidationFactor
-      350000000000000000000000 // supplyCap
+      825_000_000_000_000_000, // borrowCollateralFactor
+      895_000_000_000_000_000, // liquidateCollateralFactor
+      950_000_000_000_000_000, // liquidationFactor
+      350_000_000_000_000_000_000_000 // supplyCap
     );
     _assetConfigs[3] = AssetConfig(
       0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, // asset, UNI
       0x553303d460EE0afB37EdFf9bE42922D8FF63220e, // priceFeed
       18, // decimals
-      750000000000000000, // borrowCollateralFactor
-      810000000000000000, // liquidateCollateralFactor
-      930000000000000000, // liquidationFactor
-      2300000000000000000000000 // supplyCap
+      750_000_000_000_000_000, // borrowCollateralFactor
+      810_000_000_000_000_000, // liquidateCollateralFactor
+      930_000_000_000_000_000, // liquidationFactor
+      2_300_000_000_000_000_000_000_000 // supplyCap
     );
     _assetConfigs[4] = AssetConfig(
       0x514910771AF9Ca656af840dff83E8264EcF986CA, // asset, LINK
       0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c, // priceFeed
       18, // decimals
-      790000000000000000, // borrowCollateralFactor
-      850000000000000000, // liquidateCollateralFactor
-      930000000000000000, // liquidationFactor
-      1250000000000000000000000 // supplyCap
+      790_000_000_000_000_000, // borrowCollateralFactor
+      850_000_000_000_000_000, // liquidateCollateralFactor
+      930_000_000_000_000_000, // liquidationFactor
+      1_250_000_000_000_000_000_000_000 // supplyCap
     );
     Configuration memory _config = Configuration(
       COMPOUND_GOVERNOR,
       0xbbf3f1421D886E9b2c5D716B5192aC998af2012c, // pauseGuardian
       address(govToken), // baseToken
-      0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6, // baseTokenPriceFeed, using the chainlink USDC/USD price feed
+      0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6, // baseTokenPriceFeed, using the chainlink
+        // USDC/USD price feed
       0x285617313887d43256F852cAE0Ee4de4b68D45B0, // extensionDelegate
-      800000000000000000, // supplyKink
-      1030568239 * 60 * 60 * 24 * 365, // supplyPerYearInterestRateSlopeLow
-      12683916793 * 60 * 60 * 24 * 365, // supplyPerYearInterestRateSlopeHigh
+      800_000_000_000_000_000, // supplyKink
+      1_030_568_239 * 60 * 60 * 24 * 365, // supplyPerYearInterestRateSlopeLow
+      12_683_916_793 * 60 * 60 * 24 * 365, // supplyPerYearInterestRateSlopeHigh
       0, // supplyPerYearInterestRateBase
-      800000000000000000, // borrowKink
-      1109842719 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateSlopeLow
-      7927447995 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateSlopeHigh
-      475646879 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateBase
-      600000000000000000, // storeFrontPriceFactor
-      1000000000000000, // trackingIndexScale
+      800_000_000_000_000_000, // borrowKink
+      1_109_842_719 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateSlopeLow
+      7_927_447_995 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateSlopeHigh
+      475_646_879 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateBase
+      600_000_000_000_000_000, // storeFrontPriceFactor
+      1_000_000_000_000_000, // trackingIndexScale
       0, // baseTrackingSupplySpeed
-      3257060185185, // baseTrackingBorrowSpeed
-      1000000000000, // baseMinForRewards
-      100000000, // baseBorrowMin
-      5000000000000, // targetReserves
+      3_257_060_185_185, // baseTrackingBorrowSpeed
+      1_000_000_000_000, // baseMinForRewards
+      100_000_000, // baseBorrowMin
+      5_000_000_000_000, // targetReserves
       _assetConfigs
     );
 
@@ -222,7 +223,7 @@ contract Setup is CometForkTest {
     assertEq(cToken.balanceOf(_supplier), 0);
     assertEq(govToken.balanceOf(address(cToken)), 0);
     assertEq(govToken.balanceOf(_supplier), 0);
-    uint256 _initSupply = 1_000 ether;
+    uint256 _initSupply = 1000 ether;
     govToken.exposed_mint(_supplier, _initSupply);
     govToken.approve(address(cToken), type(uint256).max);
     cToken.supply(address(govToken), _initSupply);
@@ -275,10 +276,7 @@ contract Setup is CometForkTest {
     // Get that yield fool!
     vm.prank(_supplier);
     cToken.withdraw(address(govToken), govToken.balanceOf(address(cToken)));
-    assertTrue(
-      govToken.balanceOf(_supplier) > _initSupply,
-      "Supplier didn't actually earn yield"
-    );
+    assertTrue(govToken.balanceOf(_supplier) > _initSupply, "Supplier didn't actually earn yield");
   }
 }
 
@@ -731,9 +729,7 @@ contract CastVote is CometForkTest {
     );
   }
 
-  function _testVoteWeightIsScaledBasedOnPoolBalance(
-    VoteWeightIsScaledVars memory _vars
-  ) private {
+  function _testVoteWeightIsScaledBasedOnPoolBalance(VoteWeightIsScaledVars memory _vars) private {
     // This would be a vm.assume if we could do fuzz tests.
     assertLt(_vars.voteWeightA + _vars.voteWeightB, type(uint128).max);
 

--- a/test/CometFlexVotingFork.t.sol
+++ b/test/CometFlexVotingFork.t.sol
@@ -735,98 +735,96 @@ contract CastVote is CometForkTest {
     );
   }
 
-  function _testVoteWeightIsScaledBasedOnPoolBalance(VoteWeightIsScaledVars memory _vars) private {
-    // TODO
-    // // This would be a vm.assume if we could do fuzz tests.
-    // assertLt(_vars.voteWeightA + _vars.voteWeightB, type(uint128).max);
-    //
-    // // Deposit some funds.
-    // _mintGovAndSupplyToCompound(_vars.voterA, _vars.voteWeightA);
-    // _mintGovAndSupplyToCompound(_vars.voterB, _vars.voteWeightB);
-    // uint256 _initGovBalance = govToken.balanceOf(address(cToken));
-    //
-    // // Borrow GOV from the cToken, decreasing its token balance.
-    // deal(weth, _vars.borrower, _vars.borrowerAssets);
-    // vm.startPrank(_vars.borrower);
-    // ERC20(weth).approve(address(cToken), type(uint256).max);
-    // cToken.supply(weth, _vars.borrowerAssets, _vars.borrower, 0);
-    // // Borrow GOV against WETH
-    // cToken.borrow(
-    //   address(govToken),
-    //   (_vars.voteWeightA + _vars.voteWeightB) / 7, // amount of GOV to borrow
-    //   uint256(DataTypes.InterestRateMode.STABLE), // interestRateMode
-    //   0, // referralCode
-    //   _vars.borrower // onBehalfOf
-    // );
-    // assertLt(govToken.balanceOf(address(cToken)), _initGovBalance);
-    // govToken.delegate(_vars.borrower);
-    // vm.stopPrank();
-    //
-    // // Create the proposal.
-    // uint256 _proposalId = _createAndSubmitProposal();
-    //
-    // // Jump ahead to the proposal snapshot to lock in the cToken's balance.
-    // vm.roll(flexVotingGovernor.proposalSnapshot(_proposalId) + 1);
-    // uint256 _expectedVotingWeight = govToken.balanceOf(address(cToken));
-    // assert(_expectedVotingWeight < _initGovBalance);
-    //
-    // // A+B express votes
-    // vm.prank(_vars.voterA);
-    // cToken.expressVote(_proposalId, _vars.supportTypeA);
-    // vm.prank(_vars.voterB);
-    // cToken.expressVote(_proposalId, _vars.supportTypeB);
-    //
-    // // Submit votes on behalf of the cToken.
-    // cToken.castVote(_proposalId);
-    //
-    // // Vote should be cast as a percentage of the depositer's expressed types, since
-    // // the actual weight is different from the deposit weight.
-    // (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
-    //   flexVotingGovernor.proposalVotes(_proposalId);
-    //
-    // // These can differ because votes are rounded.
-    // assertApproxEqAbs(_againstVotes + _forVotes + _abstainVotes, _expectedVotingWeight, 1);
-    //
-    // // forgefmt: disable-start
-    // if (_vars.supportTypeA == _vars.supportTypeB) {
-    //   assertEq(_forVotes, _vars.supportTypeA == uint8(VoteType.For) ? _expectedVotingWeight : 0);
-    //   assertEq(_againstVotes, _vars.supportTypeA == uint8(VoteType.Against) ? _expectedVotingWeight : 0);
-    //   assertEq(_abstainVotes, _vars.supportTypeA == uint8(VoteType.Abstain) ? _expectedVotingWeight : 0);
-    // } else {
-    //   uint256 _expectedVotingWeightA = (_vars.voteWeightA * _expectedVotingWeight) / _initGovBalance;
-    //   uint256 _expectedVotingWeightB = (_vars.voteWeightB * _expectedVotingWeight) / _initGovBalance;
-    //
-    //   // We assert the weight is within a range of 1 because scaled weights are sometimes floored.
-    //   if (_vars.supportTypeA == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightA, 1);
-    //   if (_vars.supportTypeB == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightB, 1);
-    //   if (_vars.supportTypeA == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightA, 1);
-    //   if (_vars.supportTypeB == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightB, 1);
-    //   if (_vars.supportTypeA == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightA, 1);
-    //   if (_vars.supportTypeB == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightB, 1);
-    // }
-    // // forgefmt: disable-end
-    //
-    // // The borrower should also be able to submit votes!
-    // vm.prank(_vars.borrower);
-    // flexVotingGovernor.castVoteWithReasonAndParams(
-    //   _proposalId,
-    //   uint8(VoteType.For),
-    //   "Vote from the person that borrowed Gov from Aave",
-    //   new bytes(0) // Vote nominally so that all of the borrower's weight is used.
-    // );
-    //
-    // (_againstVotes, _forVotes, _abstainVotes) = flexVotingGovernor.proposalVotes(_proposalId);
-    // // The summed votes should now ~equal the amount of Gov initially supplied,
-    // // since the borrower also voted. There can be off-by-one errors because
-    // // the cToken rounds vote weights down before casting, but the total voting
-    // // weight expressed should be constrained by the amount of govToken injected into
-    // // the system. This ensures there's no double counting possible.
-    // assertApproxEqAbs(
-    //   _initGovBalance,
-    //   _againstVotes + _forVotes + _abstainVotes,
-    //   1,
-    //   "the number of votes cast does not match the amount of gov minted"
-    // );
+  function _testVoteWeightIsScaledBasedOnPoolBalance(
+    VoteWeightIsScaledVars memory _vars
+  ) private {
+    // This would be a vm.assume if we could do fuzz tests.
+    assertLt(_vars.voteWeightA + _vars.voteWeightB, type(uint128).max);
+
+    // Deposit some funds.
+    _mintGovAndSupplyToCompound(_vars.voterA, _vars.voteWeightA);
+    _mintGovAndSupplyToCompound(_vars.voterB, _vars.voteWeightB);
+    uint256 _initGovBalance = govToken.balanceOf(address(cToken));
+
+    // Borrow GOV from the cToken, decreasing its token balance.
+    deal(weth, _vars.borrower, _vars.borrowerAssets);
+    vm.startPrank(_vars.borrower);
+    ERC20(weth).approve(address(cToken), type(uint256).max);
+    cToken.supply(weth, _vars.borrowerAssets);
+    // Borrow GOV against WETH
+    cToken.withdraw(
+      address(govToken),
+      (_vars.voteWeightA + _vars.voteWeightB) / 7 // amount of GOV to borrow
+    );
+    assertLt(govToken.balanceOf(address(cToken)), _initGovBalance);
+    govToken.delegate(_vars.borrower);
+    vm.stopPrank();
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Jump ahead to the proposal snapshot to lock in the cToken's balance.
+    vm.roll(flexVotingGovernor.proposalSnapshot(_proposalId) + 1);
+    uint256 _expectedVotingWeight = govToken.balanceOf(address(cToken));
+    assert(_expectedVotingWeight < _initGovBalance);
+
+    // A+B express votes
+    vm.prank(_vars.voterA);
+    cToken.expressVote(_proposalId, _vars.supportTypeA);
+    vm.prank(_vars.voterB);
+    cToken.expressVote(_proposalId, _vars.supportTypeB);
+
+    // Submit votes on behalf of the cToken.
+    cToken.castVote(_proposalId);
+
+    // Vote should be cast as a percentage of the depositer's expressed types, since
+    // the actual weight is different from the deposit weight.
+    (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
+      flexVotingGovernor.proposalVotes(_proposalId);
+
+    // These can differ because votes are rounded.
+    assertApproxEqAbs(_againstVotes + _forVotes + _abstainVotes, _expectedVotingWeight, 1);
+
+    // forgefmt: disable-start
+    if (_vars.supportTypeA == _vars.supportTypeB) {
+      assertEq(_forVotes, _vars.supportTypeA == uint8(VoteType.For) ? _expectedVotingWeight : 0);
+      assertEq(_againstVotes, _vars.supportTypeA == uint8(VoteType.Against) ? _expectedVotingWeight : 0);
+      assertEq(_abstainVotes, _vars.supportTypeA == uint8(VoteType.Abstain) ? _expectedVotingWeight : 0);
+    } else {
+      uint256 _expectedVotingWeightA = (_vars.voteWeightA * _expectedVotingWeight) / _initGovBalance;
+      uint256 _expectedVotingWeightB = (_vars.voteWeightB * _expectedVotingWeight) / _initGovBalance;
+
+      // We assert the weight is within a range of 1 because scaled weights are sometimes floored.
+      if (_vars.supportTypeA == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightA, 1);
+      if (_vars.supportTypeB == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightB, 1);
+      if (_vars.supportTypeA == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightA, 1);
+      if (_vars.supportTypeB == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightB, 1);
+      if (_vars.supportTypeA == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightA, 1);
+      if (_vars.supportTypeB == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightB, 1);
+    }
+    // forgefmt: disable-end
+
+    // The borrower should also be able to submit votes!
+    vm.prank(_vars.borrower);
+    flexVotingGovernor.castVoteWithReasonAndParams(
+      _proposalId,
+      uint8(VoteType.For),
+      "Vote from the person that borrowed Gov from Aave",
+      new bytes(0) // Vote nominally so that all of the borrower's weight is used.
+    );
+
+    (_againstVotes, _forVotes, _abstainVotes) = flexVotingGovernor.proposalVotes(_proposalId);
+    // The summed votes should now ~equal the amount of Gov initially supplied,
+    // since the borrower also voted. There can be off-by-one errors because
+    // the cToken rounds vote weights down before casting, but the total voting
+    // weight expressed should be constrained by the amount of govToken injected into
+    // the system. This ensures there's no double counting possible.
+    assertApproxEqAbs(
+      _initGovBalance,
+      _againstVotes + _forVotes + _abstainVotes,
+      1,
+      "the number of votes cast does not match the amount of gov minted"
+    );
   }
 
   function test_AgainstVotingWeightIsAbandonedIfSomeoneDoesntExpress() public {

--- a/test/CometFlexVotingFork.t.sol
+++ b/test/CometFlexVotingFork.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.10;
 
 import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
+import "forge-std/console2.sol";
 
 import { IVotes } from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -288,9 +289,19 @@ contract Setup is CometForkTest {
 contract CastVote is CometForkTest {
   function test_UserCanCastAgainstVotes() public {
     _testUserCanCastVotes(
-      makeAddr("test_UserCanCastAgainstVotes address"),
-      4242 ether, // voteWeight
-      uint8(VoteType.Against) // vote type
+      makeAddr("test_UserCanCastAgainstVotes address"), 4242 ether, uint8(VoteType.Against)
+    );
+  }
+
+  function test_UserCanCastForVotes() public {
+    _testUserCanCastVotes(
+      makeAddr("test_UserCanCastForVotes address"), 4242 ether, uint8(VoteType.For)
+    );
+  }
+
+  function test_UserCanCastAbstainVotes() public {
+    _testUserCanCastVotes(
+      makeAddr("test_UserCanCastAbstainVotes address"), 4242 ether, uint8(VoteType.Abstain)
     );
   }
 
@@ -337,5 +348,753 @@ contract CastVote is CometForkTest {
     assertEq(_forVotes, _forVotesExpressed, "for votes not as expected");
     assertEq(_againstVotes, _againstVotesExpressed, "against votes not as expected");
     assertEq(_abstainVotes, _abstainVotesExpressed, "abstain votes not as expected");
+  }
+
+  function test_UserCannotExpressAgainstVotesWithoutWeight() public {
+    _testUserCannotExpressVotesWithoutCTokens(
+      makeAddr("test_UserCannotExpressAgainstVotesWithoutWeight address"),
+      0.42 ether,
+      uint8(VoteType.Against)
+    );
+  }
+
+  function test_UserCannotExpressForVotesWithoutWeight() public {
+    _testUserCannotExpressVotesWithoutCTokens(
+      makeAddr("test_UserCannotExpressForVotesWithoutWeight address"),
+      0.42 ether,
+      uint8(VoteType.For)
+    );
+  }
+
+  function test_UserCannotExpressAbstainVotesWithoutWeight() public {
+    _testUserCannotExpressVotesWithoutCTokens(
+      makeAddr("test_UserCannotExpressAbstainVotesWithoutWeight address"),
+      0.42 ether,
+      uint8(VoteType.Abstain)
+    );
+  }
+
+  function _testUserCannotExpressVotesWithoutCTokens(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Mint gov but do not deposit
+    govToken.exposed_mint(_who, _voteWeight);
+    vm.prank(_who);
+    govToken.approve(address(cToken), type(uint256).max);
+
+    assertEq(govToken.balanceOf(_who), _voteWeight);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // _who should NOT be able to express his/her vote on the proposal
+    vm.expectRevert(bytes("no weight"));
+    vm.prank(_who);
+    cToken.expressVote(_proposalId, uint8(_supportType));
+  }
+
+  function test_UserCannotCastAfterVotingPeriodAgainst() public {
+    _testUserCannotCastAfterVotingPeriod(
+      makeAddr("test_UserCannotCastAfterVotingPeriodAbstain address"),
+      4.2 ether,
+      uint8(VoteType.Against)
+    );
+  }
+
+  function test_UserCannotCastAfterVotingPeriodFor() public {
+    _testUserCannotCastAfterVotingPeriod(
+      makeAddr("test_UserCannotCastAfterVotingPeriodAbstain address"),
+      4.2 ether,
+      uint8(VoteType.For)
+    );
+  }
+
+  function test_UserCannotCastAfterVotingPeriodAbstain() public {
+    _testUserCannotCastAfterVotingPeriod(
+      makeAddr("test_UserCannotCastAfterVotingPeriodAbstain address"),
+      4.2 ether,
+      uint8(VoteType.Abstain)
+    );
+  }
+
+  function _testUserCannotCastAfterVotingPeriod(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToCompound(_who, _voteWeight);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Express vote preference.
+    vm.prank(_who);
+    cToken.expressVote(_proposalId, _supportType);
+
+    // Jump ahead so that we're outside of the proposal's voting period.
+    vm.roll(flexVotingGovernor.proposalDeadline(_proposalId) + 1);
+
+    // We should not be able to castVote at this point.
+    vm.expectRevert(bytes("Governor: vote not currently active"));
+    cToken.castVote(_proposalId);
+  }
+
+  function test_UserCannotDoubleVoteAfterVotingAgainst() public {
+    _tesNoDoubleVoting(
+      makeAddr("test_UserCannotDoubleVoteAfterVoting address"), 0.042 ether, uint8(VoteType.Against)
+    );
+  }
+
+  function test_UserCannotDoubleVoteAfterVotingFor() public {
+    _tesNoDoubleVoting(
+      makeAddr("test_UserCannotDoubleVoteAfterVoting address"), 0.042 ether, uint8(VoteType.For)
+    );
+  }
+
+  function test_UserCannotDoubleVoteAfterVotingAbstain() public {
+    _tesNoDoubleVoting(
+      makeAddr("test_UserCannotDoubleVoteAfterVoting address"), 0.042 ether, uint8(VoteType.Abstain)
+    );
+  }
+
+  function _tesNoDoubleVoting(address _who, uint256 _voteWeight, uint8 _supportType) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToCompound(_who, _voteWeight);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // _who should now be able to express his/her vote on the proposal.
+    vm.prank(_who);
+    cToken.expressVote(_proposalId, _supportType);
+
+    // Vote early and often.
+    vm.expectRevert(bytes("already voted"));
+    vm.prank(_who);
+    cToken.expressVote(_proposalId, _supportType);
+  }
+
+  function test_UserCannotCastVotesTwiceAfterVotingAgainst() public {
+    _testUserCannotCastVotesTwice(
+      makeAddr("test_UserCannotCastVotesTwiceAfterVoting address"),
+      1.42 ether,
+      uint8(VoteType.Against)
+    );
+  }
+
+  function test_UserCannotCastVotesTwiceAfterVotingFor() public {
+    _testUserCannotCastVotesTwice(
+      makeAddr("test_UserCannotCastVotesTwiceAfterVoting address"), 1.42 ether, uint8(VoteType.For)
+    );
+  }
+
+  function test_UserCannotCastVotesTwiceAfterVotingAbstain() public {
+    _testUserCannotCastVotesTwice(
+      makeAddr("test_UserCannotCastVotesTwiceAfterVoting address"),
+      1.42 ether,
+      uint8(VoteType.Abstain)
+    );
+  }
+
+  function _testUserCannotCastVotesTwice(address _who, uint256 _voteWeight, uint8 _supportType)
+    private
+  {
+    // Deposit some funds.
+    _mintGovAndSupplyToCompound(_who, _voteWeight);
+
+    // Have someone else deposit as well so that _who isn't the only one.
+    _mintGovAndSupplyToCompound(makeAddr("testUserCannotCastVotesTwice"), _voteWeight);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // _who should now be able to express his/her vote on the proposal.
+    vm.prank(_who);
+    cToken.expressVote(_proposalId, _supportType);
+
+    // Submit votes on behalf of the pool.
+    cToken.castVote(_proposalId);
+
+    // Try to submit them again.
+    vm.expectRevert("no votes expressed");
+    cToken.castVote(_proposalId);
+  }
+
+  function test_UserCannotExpressAgainstVotesPriorToDepositing() public {
+    _testUserCannotExpressVotesPriorToDepositing(
+      makeAddr("UserCannotExpressVotesPriorToDepositing address"),
+      4.242 ether,
+      uint8(VoteType.Against)
+    );
+  }
+
+  function test_UserCannotExpressForVotesPriorToDepositing() public {
+    _testUserCannotExpressVotesPriorToDepositing(
+      makeAddr("UserCannotExpressVotesPriorToDepositing address"),
+      4.242 ether, // Vote weight.
+      uint8(VoteType.For)
+    );
+  }
+
+  function test_UserCannotExpressAbstainVotesPriorToDepositing() public {
+    _testUserCannotExpressVotesPriorToDepositing(
+      makeAddr("UserCannotExpressVotesPriorToDepositing address"),
+      4.242 ether,
+      uint8(VoteType.Abstain)
+    );
+  }
+
+  function _testUserCannotExpressVotesPriorToDepositing(
+    address _who,
+    uint256 _voteWeight,
+    uint8 _supportType
+  ) private {
+    // Create the proposal *before* the user deposits anything.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Deposit some funds.
+    _mintGovAndSupplyToCompound(_who, _voteWeight);
+
+    // Now try to express a voting preference on the proposal.
+    vm.expectRevert(bytes("no weight"));
+    vm.prank(_who);
+    cToken.expressVote(_proposalId, _supportType);
+  }
+
+  function test_UserAgainstVotingWeightIsSnapshotDependent() public {
+    _testUserVotingWeightIsSnapshotDependent(
+      makeAddr("UserVotingWeightIsSnapshotDependent address"),
+      0.00042 ether,
+      0.042 ether,
+      uint8(VoteType.Against)
+    );
+  }
+
+  function test_UserForVotingWeightIsSnapshotDependent() public {
+    _testUserVotingWeightIsSnapshotDependent(
+      makeAddr("UserVotingWeightIsSnapshotDependent address"),
+      0.00042 ether,
+      0.042 ether,
+      uint8(VoteType.For)
+    );
+  }
+
+  function test_UserAbstainVotingWeightIsSnapshotDependent() public {
+    _testUserVotingWeightIsSnapshotDependent(
+      makeAddr("UserVotingWeightIsSnapshotDependent address"),
+      0.00042 ether,
+      0.042 ether,
+      uint8(VoteType.Abstain)
+    );
+  }
+
+  function _testUserVotingWeightIsSnapshotDependent(
+    address _who,
+    uint256 _voteWeightA,
+    uint256 _voteWeightB,
+    uint8 _supportType
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToCompound(_who, _voteWeightA);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Sometime later the user deposits some more.
+    vm.roll(flexVotingGovernor.proposalDeadline(_proposalId) - 1);
+    _mintGovAndSupplyToCompound(_who, _voteWeightB);
+
+    vm.prank(_who);
+    cToken.expressVote(_proposalId, _supportType);
+
+    // The internal proposal vote weight should not reflect the new deposit weight.
+    (uint256 _againstVotesExpressed, uint256 _forVotesExpressed, uint256 _abstainVotesExpressed) =
+      cToken.proposalVotes(_proposalId);
+    assertEq(_forVotesExpressed, _supportType == uint8(VoteType.For) ? _voteWeightA : 0);
+    assertEq(_againstVotesExpressed, _supportType == uint8(VoteType.Against) ? _voteWeightA : 0);
+    assertEq(_abstainVotesExpressed, _supportType == uint8(VoteType.Abstain) ? _voteWeightA : 0);
+
+    // Submit votes on behalf of the pool.
+    cToken.castVote(_proposalId);
+
+    // Votes cast should likewise reflect only the earlier balance.
+    (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
+      flexVotingGovernor.proposalVotes(_proposalId);
+    assertEq(_forVotes, _supportType == uint8(VoteType.For) ? _voteWeightA : 0);
+    assertEq(_againstVotes, _supportType == uint8(VoteType.Against) ? _voteWeightA : 0);
+    assertEq(_abstainVotes, _supportType == uint8(VoteType.Abstain) ? _voteWeightA : 0);
+  }
+
+  function test_MultipleUsersCanCastVotes() public {
+    _testMultipleUsersCanCastVotes(
+      makeAddr("MultipleUsersCanCastVotes address 1"),
+      makeAddr("MultipleUsersCanCastVotes address 2"),
+      0.42424242 ether,
+      0.00000042 ether
+    );
+  }
+
+  function _testMultipleUsersCanCastVotes(
+    address _userA,
+    address _userB,
+    uint256 _voteWeightA,
+    uint256 _voteWeightB
+  ) private {
+    // Deposit some funds.
+    _mintGovAndSupplyToCompound(_userA, _voteWeightA);
+    _mintGovAndSupplyToCompound(_userB, _voteWeightB);
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Users should now be able to express their votes on the proposal.
+    vm.prank(_userA);
+    cToken.expressVote(_proposalId, uint8(VoteType.Against));
+    vm.prank(_userB);
+    cToken.expressVote(_proposalId, uint8(VoteType.Abstain));
+
+    (uint256 _againstVotesExpressed, uint256 _forVotesExpressed, uint256 _abstainVotesExpressed) =
+      cToken.proposalVotes(_proposalId);
+    assertEq(_forVotesExpressed, 0);
+    assertEq(_againstVotesExpressed, _voteWeightA);
+    assertEq(_abstainVotesExpressed, _voteWeightB);
+
+    // The governor should have not recieved any votes yet.
+    (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
+      flexVotingGovernor.proposalVotes(_proposalId);
+    assertEq(_forVotes, 0);
+    assertEq(_againstVotes, 0);
+    assertEq(_abstainVotes, 0);
+
+    // Submit votes on behalf of the pool.
+    cToken.castVote(_proposalId);
+
+    // Governor should now record votes for the pool.
+    (_againstVotes, _forVotes, _abstainVotes) = flexVotingGovernor.proposalVotes(_proposalId);
+    assertEq(_forVotes, 0);
+    assertEq(_againstVotes, _voteWeightA);
+    assertEq(_abstainVotes, _voteWeightB);
+  }
+
+  struct VoteWeightIsScaledVars {
+    address voterA;
+    address voterB;
+    address borrower;
+    uint256 voteWeightA;
+    uint256 voteWeightB;
+    uint256 borrowerAssets;
+    uint8 supportTypeA;
+    uint8 supportTypeB;
+  }
+
+  function test_VoteWeightIsScaledBasedOnPoolBalanceAgainstFor() public {
+    _testVoteWeightIsScaledBasedOnPoolBalance(
+      VoteWeightIsScaledVars(
+        makeAddr("VoteWeightIsScaledBasedOnPoolBalance voterA #1"),
+        makeAddr("VoteWeightIsScaledBasedOnPoolBalance voterB #1"),
+        makeAddr("VoteWeightIsScaledBasedOnPoolBalance borrower #1"),
+        12 ether, // voteWeightA
+        4 ether, // voteWeightB
+        7 ether, // borrowerAssets
+        uint8(VoteType.Against), // supportTypeA
+        uint8(VoteType.For) // supportTypeB
+      )
+    );
+  }
+
+  function test_VoteWeightIsScaledBasedOnPoolBalanceAgainstAbstain() public {
+    _testVoteWeightIsScaledBasedOnPoolBalance(
+      VoteWeightIsScaledVars(
+        makeAddr("VoteWeightIsScaledBasedOnPoolBalance voterA #2"),
+        makeAddr("VoteWeightIsScaledBasedOnPoolBalance voterB #2"),
+        makeAddr("VoteWeightIsScaledBasedOnPoolBalance borrower #2"),
+        2 ether, // voteWeightA
+        7 ether, // voteWeightB
+        4 ether, // borrowerAssets
+        uint8(VoteType.Against), // supportTypeA
+        uint8(VoteType.Abstain) // supportTypeB
+      )
+    );
+  }
+
+  function test_VoteWeightIsScaledBasedOnPoolBalanceForAbstain() public {
+    _testVoteWeightIsScaledBasedOnPoolBalance(
+      VoteWeightIsScaledVars(
+        makeAddr("VoteWeightIsScaledBasedOnPoolBalance voterA #3"),
+        makeAddr("VoteWeightIsScaledBasedOnPoolBalance voterB #3"),
+        makeAddr("VoteWeightIsScaledBasedOnPoolBalance borrower #3"),
+        1 ether, // voteWeightA
+        1 ether, // voteWeightB
+        1 ether, // borrowerAssets
+        uint8(VoteType.For), // supportTypeA
+        uint8(VoteType.Abstain) // supportTypeB
+      )
+    );
+  }
+
+  function _testVoteWeightIsScaledBasedOnPoolBalance(VoteWeightIsScaledVars memory _vars) private {
+    // TODO
+    // // This would be a vm.assume if we could do fuzz tests.
+    // assertLt(_vars.voteWeightA + _vars.voteWeightB, type(uint128).max);
+    //
+    // // Deposit some funds.
+    // _mintGovAndSupplyToCompound(_vars.voterA, _vars.voteWeightA);
+    // _mintGovAndSupplyToCompound(_vars.voterB, _vars.voteWeightB);
+    // uint256 _initGovBalance = govToken.balanceOf(address(cToken));
+    //
+    // // Borrow GOV from the cToken, decreasing its token balance.
+    // deal(weth, _vars.borrower, _vars.borrowerAssets);
+    // vm.startPrank(_vars.borrower);
+    // ERC20(weth).approve(address(cToken), type(uint256).max);
+    // cToken.supply(weth, _vars.borrowerAssets, _vars.borrower, 0);
+    // // Borrow GOV against WETH
+    // cToken.borrow(
+    //   address(govToken),
+    //   (_vars.voteWeightA + _vars.voteWeightB) / 7, // amount of GOV to borrow
+    //   uint256(DataTypes.InterestRateMode.STABLE), // interestRateMode
+    //   0, // referralCode
+    //   _vars.borrower // onBehalfOf
+    // );
+    // assertLt(govToken.balanceOf(address(cToken)), _initGovBalance);
+    // govToken.delegate(_vars.borrower);
+    // vm.stopPrank();
+    //
+    // // Create the proposal.
+    // uint256 _proposalId = _createAndSubmitProposal();
+    //
+    // // Jump ahead to the proposal snapshot to lock in the cToken's balance.
+    // vm.roll(flexVotingGovernor.proposalSnapshot(_proposalId) + 1);
+    // uint256 _expectedVotingWeight = govToken.balanceOf(address(cToken));
+    // assert(_expectedVotingWeight < _initGovBalance);
+    //
+    // // A+B express votes
+    // vm.prank(_vars.voterA);
+    // cToken.expressVote(_proposalId, _vars.supportTypeA);
+    // vm.prank(_vars.voterB);
+    // cToken.expressVote(_proposalId, _vars.supportTypeB);
+    //
+    // // Submit votes on behalf of the cToken.
+    // cToken.castVote(_proposalId);
+    //
+    // // Vote should be cast as a percentage of the depositer's expressed types, since
+    // // the actual weight is different from the deposit weight.
+    // (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
+    //   flexVotingGovernor.proposalVotes(_proposalId);
+    //
+    // // These can differ because votes are rounded.
+    // assertApproxEqAbs(_againstVotes + _forVotes + _abstainVotes, _expectedVotingWeight, 1);
+    //
+    // // forgefmt: disable-start
+    // if (_vars.supportTypeA == _vars.supportTypeB) {
+    //   assertEq(_forVotes, _vars.supportTypeA == uint8(VoteType.For) ? _expectedVotingWeight : 0);
+    //   assertEq(_againstVotes, _vars.supportTypeA == uint8(VoteType.Against) ? _expectedVotingWeight : 0);
+    //   assertEq(_abstainVotes, _vars.supportTypeA == uint8(VoteType.Abstain) ? _expectedVotingWeight : 0);
+    // } else {
+    //   uint256 _expectedVotingWeightA = (_vars.voteWeightA * _expectedVotingWeight) / _initGovBalance;
+    //   uint256 _expectedVotingWeightB = (_vars.voteWeightB * _expectedVotingWeight) / _initGovBalance;
+    //
+    //   // We assert the weight is within a range of 1 because scaled weights are sometimes floored.
+    //   if (_vars.supportTypeA == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightA, 1);
+    //   if (_vars.supportTypeB == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightB, 1);
+    //   if (_vars.supportTypeA == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightA, 1);
+    //   if (_vars.supportTypeB == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightB, 1);
+    //   if (_vars.supportTypeA == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightA, 1);
+    //   if (_vars.supportTypeB == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightB, 1);
+    // }
+    // // forgefmt: disable-end
+    //
+    // // The borrower should also be able to submit votes!
+    // vm.prank(_vars.borrower);
+    // flexVotingGovernor.castVoteWithReasonAndParams(
+    //   _proposalId,
+    //   uint8(VoteType.For),
+    //   "Vote from the person that borrowed Gov from Aave",
+    //   new bytes(0) // Vote nominally so that all of the borrower's weight is used.
+    // );
+    //
+    // (_againstVotes, _forVotes, _abstainVotes) = flexVotingGovernor.proposalVotes(_proposalId);
+    // // The summed votes should now ~equal the amount of Gov initially supplied,
+    // // since the borrower also voted. There can be off-by-one errors because
+    // // the cToken rounds vote weights down before casting, but the total voting
+    // // weight expressed should be constrained by the amount of govToken injected into
+    // // the system. This ensures there's no double counting possible.
+    // assertApproxEqAbs(
+    //   _initGovBalance,
+    //   _againstVotes + _forVotes + _abstainVotes,
+    //   1,
+    //   "the number of votes cast does not match the amount of gov minted"
+    // );
+  }
+
+  function test_AgainstVotingWeightIsAbandonedIfSomeoneDoesntExpress() public {
+    _testVotingWeightIsAbandonedIfSomeoneDoesntExpress(
+      VotingWeightIsAbandonedVars(
+        makeAddr("VotingWeightIsAbandonedIfSomeoneDoesntExpress voterA #1"),
+        makeAddr("VotingWeightIsAbandonedIfSomeoneDoesntExpress voterB #1"),
+        makeAddr("VotingWeightIsAbandonedIfSomeoneDoesntExpress borrower #1"),
+        1 ether, // voteWeightA
+        1 ether, // voteWeightB
+        1 ether, // borrowerAssets
+        uint8(VoteType.Against) // supportTypeA
+      )
+    );
+  }
+
+  function test_ForVotingWeightIsAbandonedIfSomeoneDoesntExpress() public {
+    _testVotingWeightIsAbandonedIfSomeoneDoesntExpress(
+      VotingWeightIsAbandonedVars(
+        makeAddr("VotingWeightIsAbandonedIfSomeoneDoesntExpress voterA #2"),
+        makeAddr("VotingWeightIsAbandonedIfSomeoneDoesntExpress voterB #2"),
+        makeAddr("VotingWeightIsAbandonedIfSomeoneDoesntExpress borrower #2"),
+        42 ether, // voteWeightA
+        24 ether, // voteWeightB
+        11 ether, // borrowerAssets
+        uint8(VoteType.For) // supportTypeA
+      )
+    );
+  }
+
+  function test_AbstainVotingWeightIsAbandonedIfSomeoneDoesntExpress() public {
+    _testVotingWeightIsAbandonedIfSomeoneDoesntExpress(
+      VotingWeightIsAbandonedVars(
+        makeAddr("VotingWeightIsAbandonedIfSomeoneDoesntExpress voterA #3"),
+        makeAddr("VotingWeightIsAbandonedIfSomeoneDoesntExpress voterB #3"),
+        makeAddr("VotingWeightIsAbandonedIfSomeoneDoesntExpress borrower #3"),
+        24 ether, // voteWeightA
+        42 ether, // voteWeightB
+        100 ether, // borrowerAssets
+        uint8(VoteType.Abstain) // supportTypeA
+      )
+    );
+  }
+
+  struct VotingWeightIsAbandonedVars {
+    address voterA;
+    address voterB;
+    address borrower;
+    uint256 voteWeightA;
+    uint256 voteWeightB;
+    uint256 borrowerAssets;
+    uint8 supportTypeA;
+  }
+
+  function _testVotingWeightIsAbandonedIfSomeoneDoesntExpress(
+    VotingWeightIsAbandonedVars memory _vars
+  ) private {
+    // // This would be a vm.assume if we could do fuzz tests.
+    // assertLt(_vars.voteWeightA + _vars.voteWeightB, type(uint128).max);
+    //
+    // // Deposit some funds.
+    // _mintGovAndSupplyToAave(_vars.voterA, _vars.voteWeightA);
+    // _mintGovAndSupplyToAave(_vars.voterB, _vars.voteWeightB);
+    // uint256 _initGovBalance = govToken.balanceOf(address(aToken));
+    //
+    // // Borrow GOV from the pool, decreasing its token balance.
+    // deal(weth, _vars.borrower, _vars.borrowerAssets);
+    // vm.startPrank(_vars.borrower);
+    // ERC20(weth).approve(address(pool), type(uint256).max);
+    // pool.supply(weth, _vars.borrowerAssets, _vars.borrower, 0);
+    // // Borrow GOV against WETH
+    // pool.borrow(
+    //   address(govToken),
+    //   (_vars.voteWeightA + _vars.voteWeightB) / 5, // amount of GOV to borrow
+    //   uint256(DataTypes.InterestRateMode.STABLE), // interestRateMode
+    //   0, // referralCode
+    //   _vars.borrower // onBehalfOf
+    // );
+    // assertLt(govToken.balanceOf(address(aToken)), _initGovBalance);
+    // vm.stopPrank();
+    //
+    // // Create the proposal.
+    // uint256 _proposalId = _createAndSubmitProposal();
+    //
+    // // Jump ahead to the proposal snapshot to lock in the pool's balance.
+    // vm.roll(governor.proposalSnapshot(_proposalId) + 1);
+    // uint256 _totalPossibleVotingWeight = govToken.balanceOf(address(aToken));
+    //
+    // uint256 _fullVotingWeight = govToken.balanceOf(address(aToken));
+    // assert(_fullVotingWeight < _initGovBalance);
+    // uint256 _borrowedGov = govToken.balanceOf(address(_vars.borrower));
+    // assertEq(
+    //   _fullVotingWeight,
+    //   _vars.voteWeightA + _vars.voteWeightB - _borrowedGov,
+    //   "voting weight doesn't match calculated value"
+    // );
+    //
+    // // Only user A expresses a vote.
+    // vm.prank(_vars.voterA);
+    // aToken.expressVote(_proposalId, _vars.supportTypeA);
+    //
+    // // Submit votes on behalf of the pool.
+    // aToken.castVote(_proposalId);
+    //
+    // // Vote should be cast as a percentage of the depositer's expressed types, since
+    // // the actual weight is different from the deposit weight.
+    // (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
+    //   governor.proposalVotes(_proposalId);
+    //
+    // uint256 _expectedVotingWeightA = (_vars.voteWeightA * _fullVotingWeight) / _initGovBalance;
+    // uint256 _expectedVotingWeightB = (_vars.voteWeightB * _fullVotingWeight) / _initGovBalance;
+    //
+    // // The pool *could* have voted with this much weight.
+    // assertApproxEqAbs(
+    //   _totalPossibleVotingWeight, _expectedVotingWeightA + _expectedVotingWeightB, 1
+    // );
+    //
+    // // Actually, though, the pool did not vote with all of the weight it could have.
+    // // VoterB's votes were never cast because he/she did not express his/her preference.
+    // assertApproxEqAbs(
+    //   _againstVotes + _forVotes + _abstainVotes, // The total actual weight.
+    //   _expectedVotingWeightA, // VoterB's weight has been abandoned, only A's is counted.
+    //   1
+    // );
+    //
+    // // forgefmt: disable-start
+    // // We assert the weight is within a range of 1 because scaled weights are sometimes floored.
+    // if (_vars.supportTypeA == uint8(VoteType.For)) assertApproxEqAbs(_forVotes, _expectedVotingWeightA, 1);
+    // if (_vars.supportTypeA == uint8(VoteType.Against)) assertApproxEqAbs(_againstVotes, _expectedVotingWeightA, 1);
+    // if (_vars.supportTypeA == uint8(VoteType.Abstain)) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightA, 1);
+    // // forgefmt: disable-end
+  }
+
+  function test_AgainstVotingWeightIsUnaffectedByDepositsAfterProposal() public {
+    _testVotingWeightIsUnaffectedByDepositsAfterProposal(
+      makeAddr("VotingWeightIsUnaffectedByDepositsAfterProposal voterA #1"),
+      makeAddr("VotingWeightIsUnaffectedByDepositsAfterProposal voterB #1"),
+      1 ether, // voteWeightA
+      2 ether, // voteWeightB
+      uint8(VoteType.Against) // supportTypeA
+    );
+  }
+
+  function test_ForVotingWeightIsUnaffectedByDepositsAfterProposal() public {
+    _testVotingWeightIsUnaffectedByDepositsAfterProposal(
+      makeAddr("VotingWeightIsUnaffectedByDepositsAfterProposal voterA #2"),
+      makeAddr("VotingWeightIsUnaffectedByDepositsAfterProposal voterB #2"),
+      0.42 ether, // voteWeightA
+      0.042 ether, // voteWeightB
+      uint8(VoteType.For) // supportTypeA
+    );
+  }
+
+  function test_AbstainVotingWeightIsUnaffectedByDepositsAfterProposal() public {
+    _testVotingWeightIsUnaffectedByDepositsAfterProposal(
+      makeAddr("VotingWeightIsUnaffectedByDepositsAfterProposal voterA #3"),
+      makeAddr("VotingWeightIsUnaffectedByDepositsAfterProposal voterB #3"),
+      10 ether, // voteWeightA
+      20 ether, // voteWeightB
+      uint8(VoteType.Abstain) // supportTypeA
+    );
+  }
+
+  function _testVotingWeightIsUnaffectedByDepositsAfterProposal(
+    address _voterA,
+    address _voterB,
+    uint256 _voteWeightA,
+    uint256 _voteWeightB,
+    uint8 _supportTypeA
+  ) private {
+    // This would be a vm.assume if we could do fuzz tests.
+    assertLt(_voteWeightA + _voteWeightB, type(uint128).max);
+
+    // Mint and deposit for just userA.
+    _mintGovAndSupplyToCompound(_voterA, _voteWeightA);
+    uint256 _initGovBalance = govToken.balanceOf(address(cToken));
+
+    // Create the proposal.
+    uint256 _proposalId = _createAndSubmitProposal();
+
+    // Jump ahead to the proposal snapshot to lock in the cToken's balance.
+    vm.roll(flexVotingGovernor.proposalSnapshot(_proposalId) + 1);
+
+    // Now mint and deposit for userB.
+    _mintGovAndSupplyToCompound(_voterB, _voteWeightB);
+
+    uint256 _fullVotingWeight = govToken.balanceOf(address(cToken));
+    assert(_fullVotingWeight > _initGovBalance);
+    assertEq(_fullVotingWeight, _voteWeightA + _voteWeightB);
+
+    // Only user A expresses a vote.
+    vm.prank(_voterA);
+    cToken.expressVote(_proposalId, _supportTypeA);
+
+    // Submit votes on behalf of the cToken.
+    cToken.castVote(_proposalId);
+
+    (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
+      flexVotingGovernor.proposalVotes(_proposalId);
+
+    if (_supportTypeA == uint8(VoteType.For)) assertEq(_forVotes, _voteWeightA);
+    if (_supportTypeA == uint8(VoteType.Against)) assertEq(_againstVotes, _voteWeightA);
+    if (_supportTypeA == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _voteWeightA);
+  }
+
+  function test_AgainstVotingWeightDoesNotGoDownWhenUsersBorrow() public {
+    _testVotingWeightDoesNotGoDownWhenUsersBorrow(
+      makeAddr("VotingWeightDoesNotGoDownWhenUsersBorrow address 1"),
+      4.242 ether, // GOV deposit amount
+      1 ether, // DAI borrow amount
+      uint8(VoteType.Against) // supportType
+    );
+  }
+
+  function test_ForVotingWeightDoesNotGoDownWhenUsersBorrow() public {
+    _testVotingWeightDoesNotGoDownWhenUsersBorrow(
+      makeAddr("VotingWeightDoesNotGoDownWhenUsersBorrow address 2"),
+      424.2 ether, // GOV deposit amount
+      4 ether, // DAI borrow amount
+      uint8(VoteType.For) // supportType
+    );
+  }
+
+  function test_AbstainVotingWeightDoesNotGoDownWhenUsersBorrow() public {
+    _testVotingWeightDoesNotGoDownWhenUsersBorrow(
+      makeAddr("VotingWeightDoesNotGoDownWhenUsersBorrow address 3"),
+      0.4242 ether, // GOV deposit amount
+      0.0424 ether, // DAI borrow amount
+      uint8(VoteType.Abstain) // supportType
+    );
+  }
+
+  function _testVotingWeightDoesNotGoDownWhenUsersBorrow(
+    address _who,
+    uint256 _voteWeight,
+    uint256 _borrowAmount,
+    uint8 _supportType
+  ) private {
+    // TODO can this be done on compound?
+    // // Mint and deposit.
+    // _mintGovAndSupplyToCompound(_who, _voteWeight);
+    //
+    // // Borrow DAI against GOV position.
+    // vm.prank(_who);
+    // cToken.borrow(
+    //   dai,
+    //   _borrowAmount,
+    //   uint256(DataTypes.InterestRateMode.STABLE), // interestRateMode
+    //   0, // referralCode
+    //   _who // onBehalfOf
+    // );
+    //
+    // // Create the proposal.
+    // uint256 _proposalId = _createAndSubmitProposal();
+    //
+    // // Express voting preference.
+    // vm.prank(_who);
+    // cToken.expressVote(_proposalId, _supportType);
+    //
+    // // Submit votes on behalf of the cToken.
+    // cToken.castVote(_proposalId);
+    //
+    // (uint256 _againstVotes, uint256 _forVotes, uint256 _abstainVotes) =
+    //   flexVotingGovernor.proposalVotes(_proposalId);
+    //
+    // // Actual voting weight should match the initial deposit.
+    // if (_supportType == uint8(VoteType.For)) assertEq(_forVotes, _voteWeight);
+    // if (_supportType == uint8(VoteType.Against)) assertEq(_againstVotes, _voteWeight);
+    // if (_supportType == uint8(VoteType.Abstain)) assertEq(_abstainVotes, _voteWeight);
   }
 }

--- a/test/CometFlexVotingFork.t.sol
+++ b/test/CometFlexVotingFork.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity >=0.8.10;
+
+import { Test } from "forge-std/Test.sol";
+import { Vm } from "forge-std/Vm.sol";
+
+import { IVotes } from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+
+import { CTokenFlexVoting } from "src/CTokenFlexVoting.sol";
+import { FractionalGovernor } from "test/FractionalGovernor.sol";
+import { ProposalReceiverMock } from "test/ProposalReceiverMock.sol";
+import { GovToken } from "test/GovToken.sol";
+
+import { CometConfiguration } from "comet/CometConfiguration.sol";
+import { Comet } from "comet/Comet.sol";
+
+contract CometForkTest is Test, CometConfiguration {
+  uint256 forkId;
+
+  CTokenFlexVoting cToken;
+  // The Compound governor, not to be confused with the govToken's governance system:
+  address immutable COMPOUND_GOVERNOR = 0x6d903f6003cca6255D85CcA4D3B5E5146dC33925;
+  GovToken govToken;
+  FractionalGovernor flexVotingGovernor;
+  ProposalReceiverMock receiver;
+
+  function setUp() public {
+    // Compound v3 has been deployed to mainnet.
+    // https://docs.compound.finance/#networks
+    uint256 mainnetForkBlock = 17_146_483;
+    forkId = vm.createSelectFork(vm.rpcUrl("mainnet"), mainnetForkBlock);
+
+    // Deploy the GOV token.
+    govToken = new GovToken();
+    vm.label(address(govToken), "govToken");
+
+    // Deploy the governor.
+    flexVotingGovernor = new FractionalGovernor("Governor", IVotes(govToken));
+    vm.label(address(flexVotingGovernor), "flexVotingGovernor");
+
+    //Deploy the contract which will receive proposal calls.
+    receiver = new ProposalReceiverMock();
+    vm.label(address(receiver), "receiver");
+
+    // ========= START DEPLOY NEW COMET ========================
+    //
+    // These configs are all based on the cUSDCv3 token configs:
+    //   https://etherscan.io/address/0xc3d688B66703497DAA19211EEdff47f25384cdc3#readProxyContract
+    AssetConfig[] memory _assetConfigs = new AssetConfig[](5);
+    _assetConfigs[0] = AssetConfig(
+      0xc00e94Cb662C3520282E6f5717214004A7f26888, // asset, COMP
+      0xdbd020CAeF83eFd542f4De03e3cF0C28A4428bd5, // priceFeed
+      18, // decimals
+      650000000000000000, // borrowCollateralFactor
+      700000000000000000, // liquidateCollateralFactor
+      880000000000000000, // liquidationFactor
+      900000000000000000000000 // supplyCap
+    );
+    _assetConfigs[1] = AssetConfig(
+      0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599, // asset, WBTC
+      0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c, // priceFeed
+      8, // decimals
+      700000000000000000, // borrowCollateralFactor
+      770000000000000000, // liquidateCollateralFactor
+      950000000000000000, // liquidationFactor
+      1200000000000 // supplyCap
+    );
+    _assetConfigs[2] = AssetConfig(
+      0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, // asset, WETH
+      0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419, // priceFeed
+      18, // decimals
+      825000000000000000, // borrowCollateralFactor
+      895000000000000000, // liquidateCollateralFactor
+      950000000000000000, // liquidationFactor
+      350000000000000000000000 // supplyCap
+    );
+    _assetConfigs[3] = AssetConfig(
+      0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, // asset, UNI
+      0x553303d460EE0afB37EdFf9bE42922D8FF63220e, // priceFeed
+      18, // decimals
+      750000000000000000, // borrowCollateralFactor
+      810000000000000000, // liquidateCollateralFactor
+      930000000000000000, // liquidationFactor
+      2300000000000000000000000 // supplyCap
+    );
+    _assetConfigs[4] = AssetConfig(
+      0x514910771AF9Ca656af840dff83E8264EcF986CA, // asset, LINK
+      0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c, // priceFeed
+      18, // decimals
+      790000000000000000, // borrowCollateralFactor
+      850000000000000000, // liquidateCollateralFactor
+      930000000000000000, // liquidationFactor
+      1250000000000000000000000 // supplyCap
+    );
+    Configuration memory _config = Configuration(
+      COMPOUND_GOVERNOR,
+      0xbbf3f1421D886E9b2c5D716B5192aC998af2012c, // pauseGuardian
+      address(govToken), // baseToken
+      0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6, // baseTokenPriceFeed, using the chainlink USDC/USD price feed
+      0x285617313887d43256F852cAE0Ee4de4b68D45B0, // extensionDelegate
+      800000000000000000, // supplyKink
+      1030568239 * 60 * 60 * 24 * 365, // supplyPerYearInterestRateSlopeLow
+      12683916793 * 60 * 60 * 24 * 365, // supplyPerYearInterestRateSlopeHigh
+      0, // supplyPerYearInterestRateBase
+      800000000000000000, // borrowKink
+      1109842719 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateSlopeLow
+      7927447995 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateSlopeHigh
+      475646879 * 60 * 60 * 24 * 365, // borrowPerYearInterestRateBase
+      600000000000000000, // storeFrontPriceFactor
+      1000000000000000, // trackingIndexScale
+      0, // baseTrackingSupplySpeed
+      3257060185185, // baseTrackingBorrowSpeed
+      1000000000000, // baseMinForRewards
+      100000000, // baseBorrowMin
+      5000000000000, // targetReserves
+      _assetConfigs
+    );
+
+    cToken = new CTokenFlexVoting(_config, address(flexVotingGovernor));
+    // ========= END DEPLOY NEW COMET ========================
+
+    // TODO is there anything we need to do to make this an "official" Comet?
+  }
+}
+
+contract Setup is CometForkTest {
+  function testFork_SetupCTokenDeploy() public {
+    assertEq(cToken.governor(), COMPOUND_GOVERNOR);
+    assertEq(cToken.baseToken(), address(govToken));
+    assertEq(address(cToken.GOVERNOR()), address(flexVotingGovernor));
+
+    assertEq(
+      govToken.delegates(address(cToken)),
+      address(cToken),
+      // The CToken should be delegating to itself.
+      "cToken is not delegating to itself"
+    );
+  }
+}

--- a/test/CometFlexVotingFork.t.sol
+++ b/test/CometFlexVotingFork.t.sol
@@ -165,7 +165,8 @@ contract CometForkTest is Test, CometConfiguration {
     if (block.number == 0) vm.roll(42);
 
     // Create a dummy proposal.
-    bytes memory receiverCallData = abi.encodeWithSelector(ProposalReceiverMock.mockRecieverFunction.selector);
+    bytes memory receiverCallData =
+      abi.encodeWithSelector(ProposalReceiverMock.mockRecieverFunction.selector);
     address[] memory targets = new address[](1);
     uint256[] memory values = new uint256[](1);
     bytes[] memory calldatas = new bytes[](1);
@@ -179,7 +180,11 @@ contract CometForkTest is Test, CometConfiguration {
 
     // advance proposal to active state
     vm.roll(flexVotingGovernor.proposalSnapshot(proposalId) + 1);
-    assertEq(uint256(flexVotingGovernor.state(proposalId)), uint256(ProposalState.Active), "createAndSubmitProposal: state mismatch");
+    assertEq(
+      uint256(flexVotingGovernor.state(proposalId)),
+      uint256(ProposalState.Active),
+      "createAndSubmitProposal: state mismatch"
+    );
   }
 }
 


### PR DESCRIPTION
This PR adds a flex voting client contract that is compatible with Compound V3. This was developed through support from a grant from Compound [here](https://questbook.app/dashboard/?grantId=0xeb047900b28a9f90f3c0e65768b23e7542a65163&chainId=10&proposalId=0x21b&isRenderingProposalBody=true)

Currently this PR depends upon [a fork of Compound V3](https://github.com/davidlaprade/comet/) (split from main on May 15, 2023). The [only change](https://github.com/davidlaprade/comet/commit/2921780a8cfe94f2e11cf91ebab1301daf4a76d7) was to make `Comet.updateBasePrincipal` virtual so that we could add checkpointing in the client. My intention is to upstream this change after we're aligned on the architecture of the present PR and it is approved/merged.

This PR also abstracts the flex voting client logic into a separate abstract contract called `FlexVotingClient` that can be re-used for client implementations in the future. Doing so allows us to greatly simplify the `ATokenFlexVoting` implementation of previous PRs, e.g. #11.

Note that this PR leaves a few things unfinished, e.g.:
* more thorough testing should be done (see TODO's at the bottom of the test file)
* natspec comments (both for `FlexVotingClient` and for `CometFlexVoting`)
* the Comet dependency should be updated to https://github.com/compound-finance/comet once the change is merged