### PR TITLE
Use relative imports for interfaces

### DIFF
--- a/src/FlexVotingClient.sol
+++ b/src/FlexVotingClient.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.8.10;
 
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
-import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
-import {IVotingToken} from "src/interfaces/IVotingToken.sol";
+import {IFractionalGovernor} from "./interfaces/IFractionalGovernor.sol";
+import {IVotingToken} from "./interfaces/IVotingToken.sol";
 
 /// @notice This is an abstract contract designed to make it easy to build clients
 /// for governance systems that inherit from GovernorCountingFractional, a.k.a.

--- a/src/FractionalPool.sol
+++ b/src/FractionalPool.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.10;
 
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
-import {IFractionalGovernor} from "src/interfaces/IFractionalGovernor.sol";
-import {IVotingToken} from "src/interfaces/IVotingToken.sol";
+import {IFractionalGovernor} from "./interfaces/IFractionalGovernor.sol";
+import {IVotingToken} from "./interfaces/IVotingToken.sol";
 
 ///  @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to
 ///  allow holders of governance tokens to use them in DeFi but still participate in governance. The


### PR DESCRIPTION
When importing Flexible Voting into another repository, the forge coverage tool was failing with the error: "Could not read source code for analysis" linked to the imports of interface files from the FlexibleVotingClient contract. While the non-relative imports work fine in the context of this repo, and even in the context of running tests normally when used as an import, they cause an issue for the coverage tool.

It's unclear if this is a bug with foundry or something with our configuration. Regardless, the easiest fix is simply to use relative imports, which we do here.

Read more about the issue here:
https://github.com/foundry-rs/foundry/issues/2915