### PR TITLE
Improve FlexVotingClient test structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-e649e62f125244a3ef116be25dfdc81a2afbaf2a
 
       - name: Run tests
         run: forge test

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -20,6 +20,10 @@ contract FlexVotingClientTest is Test {
   FractionalGovernor governor;
   ProposalReceiverMock receiver;
 
+  // This max is a limitation of GovernorCountingFractional's vote storage size.
+  // See GovernorCountingFractional.ProposalVote struct.
+  uint256 MAX_VOTES = type(uint128).max;
+
   function setUp() public {
     token = new GovToken();
     vm.label(address(token), "token");
@@ -90,7 +94,7 @@ contract FlexVotingClientTest is Test {
     returns (uint208 _boundedWeight)
   {
     _assumeSafeUser(_account);
-    _boundedWeight = uint208(bound(_voteWeight, 1, type(uint128).max));
+    _boundedWeight = uint208(bound(_voteWeight, 1, MAX_VOTES));
   }
 
   function _assumeSafeVoteParams(address _account, uint208 _voteWeight, uint8 _supportType)
@@ -103,7 +107,7 @@ contract FlexVotingClientTest is Test {
     _boundedSupport = _randVoteType(_supportType);
 
     // This max is a limitation of the fractional governance protocol storage.
-    _boundedWeight = uint208(bound(_voteWeight, 1, type(uint128).max));
+    _boundedWeight = uint208(bound(_voteWeight, 1, MAX_VOTES));
   }
 }
 
@@ -139,7 +143,7 @@ contract _RawBalanceOf is FlexVotingClientTest {
 
   function testFuzz_IncreasesOnDeposit(address _user, uint208 _amount) public {
     _assumeSafeUser(_user);
-    _amount = uint208(bound(_amount, 1, type(uint128).max));
+    _amount = uint208(bound(_amount, 1, MAX_VOTES));
 
     // Deposit some gov.
     _mintGovAndDepositIntoFlexClient(_user, _amount);
@@ -149,7 +153,7 @@ contract _RawBalanceOf is FlexVotingClientTest {
 
   function testFuzz_DecreasesOnWithdrawal(address _user, uint208 _amount) public {
     _assumeSafeUser(_user);
-    _amount = uint208(bound(_amount, 1, type(uint128).max));
+    _amount = uint208(bound(_amount, 1, MAX_VOTES));
 
     // Deposit some gov.
     _mintGovAndDepositIntoFlexClient(_user, _amount);
@@ -163,7 +167,7 @@ contract _RawBalanceOf is FlexVotingClientTest {
 
   function testFuzz_UnaffectedByBorrow(address _user, uint208 _deposit, uint208 _borrow) public {
     _assumeSafeUser(_user);
-    _deposit = uint208(bound(_deposit, 1, type(uint128).max));
+    _deposit = uint208(bound(_deposit, 1, MAX_VOTES));
     _borrow = uint208(bound(_borrow, 1, _deposit));
 
     // Deposit some gov.
@@ -214,7 +218,7 @@ contract _CheckpointRawBalanceOf is FlexVotingClientTest {
   ) public {
     vm.assume(_user != address(flexClient));
     _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
-    _amount = uint208(bound(_amount, 1, type(uint128).max));
+    _amount = uint208(bound(_amount, 1, MAX_VOTES));
 
     flexClient.exposed_setDeposits(_user, _amount);
     assertEq(flexClient.getPastRawBalance(_user, _blockNum), 0);
@@ -234,7 +238,7 @@ contract GetPastRawBalance is FlexVotingClientTest {
     vm.assume(_depositor != address(flexClient));
     vm.assume(_nonDepositor != address(flexClient));
     vm.assume(_nonDepositor != _depositor);
-    _amount = uint208(bound(_amount, 1, type(uint128).max));
+    _amount = uint208(bound(_amount, 1, MAX_VOTES));
 
     vm.roll(block.number + 1);
     assertEq(flexClient.getPastRawBalance(_depositor, 0), 0);
@@ -254,7 +258,7 @@ contract GetPastRawBalance is FlexVotingClientTest {
   ) public {
     vm.assume(_user != address(flexClient));
     _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
-    _amount = uint208(bound(_amount, 1, type(uint128).max));
+    _amount = uint208(bound(_amount, 1, MAX_VOTES));
 
     _mintGovAndDepositIntoFlexClient(_user, _amount);
 
@@ -272,8 +276,8 @@ contract GetPastRawBalance is FlexVotingClientTest {
   ) public {
     vm.assume(_user != address(flexClient));
     _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
-    _amountA = uint208(bound(_amountA, 1, type(uint128).max));
-    _amountB = uint208(bound(_amountB, 0, type(uint128).max - _amountA));
+    _amountA = uint208(bound(_amountA, 1, MAX_VOTES));
+    _amountB = uint208(bound(_amountB, 0, MAX_VOTES - _amountA));
 
     _mintGovAndDepositIntoFlexClient(_user, _amountA);
     vm.roll(_blockNum);
@@ -303,7 +307,7 @@ contract GetPastTotalBalance is FlexVotingClientTest {
   ) public {
     vm.assume(_user != address(flexClient));
     _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
-    _amount = uint208(bound(_amount, 1, type(uint128).max));
+    _amount = uint208(bound(_amount, 1, MAX_VOTES));
 
     _mintGovAndDepositIntoFlexClient(_user, _amount);
 
@@ -323,8 +327,8 @@ contract GetPastTotalBalance is FlexVotingClientTest {
     vm.assume(_userB != address(flexClient));
     vm.assume(_userA != _userB);
 
-    _amountA = uint208(bound(_amountA, 1, type(uint128).max));
-    _amountB = uint208(bound(_amountB, 0, type(uint128).max - _amountA));
+    _amountA = uint208(bound(_amountA, 1, MAX_VOTES));
+    _amountB = uint208(bound(_amountB, 0, MAX_VOTES - _amountA));
 
     _mintGovAndDepositIntoFlexClient(_userA, _amountA);
     _mintGovAndDepositIntoFlexClient(_userB, _amountB);
@@ -346,8 +350,8 @@ contract GetPastTotalBalance is FlexVotingClientTest {
     vm.assume(_userA != _userB);
     _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
 
-    _amountA = uint208(bound(_amountA, 1, type(uint128).max));
-    _amountB = uint208(bound(_amountB, 0, type(uint128).max - _amountA));
+    _amountA = uint208(bound(_amountA, 1, MAX_VOTES));
+    _amountB = uint208(bound(_amountB, 0, MAX_VOTES - _amountA));
 
     assertEq(flexClient.getPastTotalBalance(block.number), 0);
 
@@ -416,8 +420,8 @@ contract Deposit is FlexVotingClientTest {
     uint208 _amountB,
     uint24 _depositDelay
   ) public {
-    _amountA = uint208(bound(_amountA, 1, type(uint128).max));
-    _amountB = uint208(bound(_amountB, 0, type(uint128).max - _amountA));
+    _amountA = uint208(bound(_amountA, 1, MAX_VOTES));
+    _amountB = uint208(bound(_amountB, 0, MAX_VOTES - _amountA));
 
     // Deposit some gov.
     _mintGovAndDepositIntoFlexClient(_user, _amountA);
@@ -593,7 +597,7 @@ contract ExpressVote is FlexVotingClientTest {
 
     vm.assume(_user != address(flexClient));
     // This max is a limitation of the fractional governance protocol storage.
-    _voteWeight = uint208(bound(_voteWeight, 1, type(uint128).max));
+    _voteWeight = uint208(bound(_voteWeight, 1, MAX_VOTES));
 
     // Deposit some funds.
     _mintGovAndDepositIntoFlexClient(_user, _voteWeight);
@@ -762,9 +766,9 @@ contract CastVote is FlexVotingClientTest {
     _vars.supportTypeA = uint8(bound(_vars.supportTypeA, 0, uint256(type(GCF.VoteType).max)));
     _vars.supportTypeB = uint8(bound(_vars.supportTypeB, 0, uint256(type(GCF.VoteType).max)));
 
-    _vars.voteWeightA = uint208(bound(_vars.voteWeightA, 1e4, type(uint128).max - 1e4 - 1));
+    _vars.voteWeightA = uint208(bound(_vars.voteWeightA, 1e4, MAX_VOTES - 1e4 - 1));
     _vars.voteWeightB =
-      uint208(bound(_vars.voteWeightB, 1e4, type(uint128).max - _vars.voteWeightA - 1));
+      uint208(bound(_vars.voteWeightB, 1e4, MAX_VOTES - _vars.voteWeightA - 1));
 
     uint208 _maxBorrowWeight = _vars.voteWeightA + _vars.voteWeightB;
     _vars.borrowAmountC = uint208(bound(_vars.borrowAmountC, 1, _maxBorrowWeight - 1));
@@ -772,7 +776,7 @@ contract CastVote is FlexVotingClientTest {
       uint208(bound(_vars.borrowAmountD, 1, _maxBorrowWeight - _vars.borrowAmountC));
 
     // These are here just as a sanity check that all of the bounding above worked.
-    vm.assume(_vars.voteWeightA + _vars.voteWeightB < type(uint128).max);
+    vm.assume(_vars.voteWeightA + _vars.voteWeightB < MAX_VOTES);
     vm.assume(_vars.voteWeightA + _vars.voteWeightB >= _vars.borrowAmountC + _vars.borrowAmountD);
 
     // Mint and deposit.
@@ -869,10 +873,10 @@ contract CastVote is FlexVotingClientTest {
     // Requirements:
     //   voteWeights and borrow each >= 1
     //   voteWeights and borrow each <= uint128.max
-    //   _voteWeightA + _voteWeightB < type(uint128).max
+    //   _voteWeightA + _voteWeightB < MAX_VOTES
     //   _voteWeightA + _voteWeightB > _borrowAmount
-    _voteWeightA = uint208(bound(_voteWeightA, 1, type(uint128).max - 2));
-    _voteWeightB = uint208(bound(_voteWeightB, 1, type(uint128).max - _voteWeightA - 1));
+    _voteWeightA = uint208(bound(_voteWeightA, 1, MAX_VOTES - 2));
+    _voteWeightB = uint208(bound(_voteWeightB, 1, MAX_VOTES - _voteWeightA - 1));
     _borrowAmount = uint208(bound(_borrowAmount, 1, _voteWeightA + _voteWeightB - 1));
     GCF.VoteType _voteTypeA = _randVoteType(_supportTypeA);
 
@@ -947,9 +951,9 @@ contract CastVote is FlexVotingClientTest {
       address(0xf005ba11) // userC
     ];
 
-    // We need _voteWeightA + _voteWeightB < type(uint128).max.
-    _voteWeightA = uint208(bound(_voteWeightA, 1, type(uint128).max - 2));
-    _voteWeightB = uint208(bound(_voteWeightB, 1, type(uint128).max - _voteWeightA - 1));
+    // We need _voteWeightA + _voteWeightB < MAX_VOTES.
+    _voteWeightA = uint208(bound(_voteWeightA, 1, MAX_VOTES - 2));
+    _voteWeightB = uint208(bound(_voteWeightB, 1, MAX_VOTES - _voteWeightA - 1));
     GCF.VoteType _voteTypeA = _randVoteType(_supportTypeA);
 
     // Mint and deposit for just userA.

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -24,6 +24,9 @@ contract FlexVotingClientTest is Test {
   // See GovernorCountingFractional.ProposalVote struct.
   uint256 MAX_VOTES = type(uint128).max;
 
+  // The highest valid vote type, represented as a uint256.
+  uint256 MAX_VOTE_TYPE = uint256(type(GCF.VoteType).max);
+
   function setUp() public {
     token = new GovToken();
     vm.label(address(token), "token");
@@ -78,10 +81,9 @@ contract FlexVotingClientTest is Test {
     vm.assume(_user != address(0));
   }
 
-  function _randVoteType(uint8 _seed) public pure returns (GCF.VoteType) {
-    return GCF.VoteType(
-      uint8(bound(uint256(_seed), uint256(type(GCF.VoteType).min), uint256(type(GCF.VoteType).max)))
-    );
+  function _randVoteType(uint8 _seed) public view returns (GCF.VoteType) {
+    return
+      GCF.VoteType(uint8(bound(uint256(_seed), uint256(type(GCF.VoteType).min), MAX_VOTE_TYPE)));
   }
 
   function _assumeSafeVoteParams(address _account, uint208 _voteWeight)
@@ -581,7 +583,7 @@ contract ExpressVote is FlexVotingClientTest {
     public
   {
     // Force vote type to be unrecognized.
-    _supportType = uint8(bound(_supportType, uint256(type(GCF.VoteType).max) + 1, type(uint8).max));
+    _supportType = uint8(bound(_supportType, MAX_VOTE_TYPE + 1, type(uint8).max));
 
     _assumeSafeUser(_user);
     _voteWeight = uint208(bound(_voteWeight, 1, MAX_VOTES));
@@ -603,9 +605,7 @@ contract ExpressVote is FlexVotingClientTest {
     uint208 _voteWeight,
     uint8 _supportType,
     uint256 _proposalId
-  )
-    public
-  {
+  ) public {
     _assumeSafeUser(_user);
     _voteWeight = uint208(bound(_voteWeight, 1, MAX_VOTES));
 
@@ -615,7 +615,7 @@ contract ExpressVote is FlexVotingClientTest {
     vm.assume(governor.proposalSnapshot(_proposalId) == 0);
 
     // Force vote type to be unrecognized.
-    _supportType = uint8(bound(_supportType, uint256(type(GCF.VoteType).max) + 1, type(uint8).max));
+    _supportType = uint8(bound(_supportType, MAX_VOTE_TYPE + 1, type(uint8).max));
 
     // Deposit some funds.
     _mintGovAndDepositIntoFlexClient(_user, _voteWeight);
@@ -781,8 +781,8 @@ contract CastVote is FlexVotingClientTest {
     _vars.userC = address(0xf005ba11);
     _vars.userD = address(0xba5eba11);
 
-    _vars.supportTypeA = uint8(bound(_vars.supportTypeA, 0, uint256(type(GCF.VoteType).max)));
-    _vars.supportTypeB = uint8(bound(_vars.supportTypeB, 0, uint256(type(GCF.VoteType).max)));
+    _vars.supportTypeA = uint8(bound(_vars.supportTypeA, 0, MAX_VOTE_TYPE));
+    _vars.supportTypeB = uint8(bound(_vars.supportTypeB, 0, MAX_VOTE_TYPE));
 
     _vars.voteWeightA = uint208(bound(_vars.voteWeightA, 1e4, MAX_VOTES - 1e4 - 1));
     _vars.voteWeightB = uint208(bound(_vars.voteWeightB, 1e4, MAX_VOTES - _vars.voteWeightA - 1));

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -200,8 +200,7 @@ contract _CheckpointRawBalanceOf is FlexVotingClientTest {
     uint48 _blockNum
   ) public {
     vm.assume(_user != address(flexClient));
-    vm.assume(_blockNum > 2);
-    vm.assume(_blockNum < type(uint48).max);
+    _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
     _amount = uint208(bound(_amount, 1, type(uint128).max));
 
     flexClient.exposed_setDeposits(_user, _amount);
@@ -241,8 +240,7 @@ contract GetPastRawBalance is FlexVotingClientTest {
     uint48 _blockNum
   ) public {
     vm.assume(_user != address(flexClient));
-    vm.assume(_blockNum > 2);
-    vm.assume(_blockNum < type(uint48).max);
+    _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
     _amount = uint208(bound(_amount, 1, type(uint128).max));
 
     _mintGovAndDepositIntoFlexClient(_user, _amount);
@@ -260,8 +258,7 @@ contract GetPastRawBalance is FlexVotingClientTest {
     uint48 _blockNum
   ) public {
     vm.assume(_user != address(flexClient));
-    vm.assume(_blockNum > 2);
-    vm.assume(_blockNum < type(uint48).max);
+    _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
     _amountA = uint208(bound(_amountA, 1, type(uint128).max));
     _amountB = uint208(bound(_amountB, 0, type(uint128).max - _amountA));
 
@@ -292,8 +289,7 @@ contract GetPastTotalBalance is FlexVotingClientTest {
     uint48 _blockNum
   ) public {
     vm.assume(_user != address(flexClient));
-    vm.assume(_blockNum > 2);
-    vm.assume(_blockNum < type(uint48).max);
+    _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
     _amount = uint208(bound(_amount, 1, type(uint128).max));
 
     _mintGovAndDepositIntoFlexClient(_user, _amount);
@@ -335,8 +331,7 @@ contract GetPastTotalBalance is FlexVotingClientTest {
     vm.assume(_userA != address(flexClient));
     vm.assume(_userB != address(flexClient));
     vm.assume(_userA != _userB);
-    vm.assume(_blockNum > 2);
-    vm.assume(_blockNum < type(uint48).max);
+    _blockNum = uint48(bound(_blockNum, block.number + 1, type(uint48).max));
 
     _amountA = uint208(bound(_amountA, 1, type(uint128).max));
     _amountB = uint208(bound(_amountB, 0, type(uint128).max - _amountA));

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -99,10 +99,7 @@ contract FlexVotingClientTest is Test {
     returns (uint208 _boundedWeight, GCF.VoteType _boundedSupport)
   {
     _assumeSafeUser(_account);
-
     _boundedSupport = _randVoteType(_supportType);
-
-    // This max is a limitation of the fractional governance protocol storage.
     _boundedWeight = uint208(bound(_voteWeight, 1, MAX_VOTES));
   }
 }
@@ -586,8 +583,7 @@ contract ExpressVote is FlexVotingClientTest {
     // Force vote type to be unrecognized.
     _supportType = uint8(bound(_supportType, uint256(type(GCF.VoteType).max) + 1, type(uint8).max));
 
-    vm.assume(_user != address(flexClient));
-    // This max is a limitation of the fractional governance protocol storage.
+    _assumeSafeUser(_user);
     _voteWeight = uint208(bound(_voteWeight, 1, MAX_VOTES));
 
     // Deposit some funds.
@@ -722,13 +718,11 @@ contract CastVote is FlexVotingClientTest {
     uint208 _voteWeightA,
     uint208 _voteWeightB
   ) public {
-    // This max is a limitation of the fractional governance protocol storage.
-    _voteWeightA = uint208(bound(_voteWeightA, 1, type(uint120).max));
-    _voteWeightB = uint208(bound(_voteWeightB, 1, type(uint120).max));
-
-    vm.assume(_userA != address(flexClient));
-    vm.assume(_userB != address(flexClient));
     vm.assume(_userA != _userB);
+    _assumeSafeUser(_userA);
+    _assumeSafeUser(_userB);
+    _voteWeightA = uint208(bound(_voteWeightA, 1, MAX_VOTES - 1));
+    _voteWeightB = uint208(bound(_voteWeightB, 1, MAX_VOTES - _voteWeightA));
 
     // Deposit some funds.
     _mintGovAndDepositIntoFlexClient(_userA, _voteWeightA);

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -78,14 +78,10 @@ contract FlexVotingClientTest is Test {
     vm.assume(_user != address(0));
   }
 
-  function _randVoteType(uint8 _seed) public view returns (GCF.VoteType) {
-    return GCF.VoteType(uint8(
-      bound(
-        uint256(_seed),
-        uint256(type(GCF.VoteType).min),
-        uint256(type(GCF.VoteType).max)
-      )
-    ));
+  function _randVoteType(uint8 _seed) public pure returns (GCF.VoteType) {
+    return GCF.VoteType(
+      uint8(bound(uint256(_seed), uint256(type(GCF.VoteType).min), uint256(type(GCF.VoteType).max)))
+    );
   }
 
   function _assumeSafeVoteParams(address _account, uint208 _voteWeight)
@@ -568,18 +564,13 @@ contract ExpressVote is FlexVotingClientTest {
       uint256 _abstainVotesExpressedInit
     ) = flexClient.proposalVotes(_proposalId);
     assertEq(_forVotesExpressedInit, _voteType == GCF.VoteType.For ? _voteWeight : 0);
-    assertEq(
-      _againstVotesExpressedInit, _voteType == GCF.VoteType.Against ? _voteWeight : 0
-    );
-    assertEq(
-      _abstainVotesExpressedInit, _voteType == GCF.VoteType.Abstain ? _voteWeight : 0
-    );
+    assertEq(_againstVotesExpressedInit, _voteType == GCF.VoteType.Against ? _voteWeight : 0);
+    assertEq(_abstainVotesExpressedInit, _voteType == GCF.VoteType.Abstain ? _voteWeight : 0);
 
     // Vote early and often!
     vm.expectRevert(bytes("already voted"));
     vm.prank(_user);
     flexClient.expressVote(_proposalId, uint8(_voteType));
-
 
     // No votes changed.
     (uint256 _againstVotesExpressed, uint256 _forVotesExpressed, uint256 _abstainVotesExpressed) =
@@ -767,8 +758,7 @@ contract CastVote is FlexVotingClientTest {
     _vars.supportTypeB = uint8(bound(_vars.supportTypeB, 0, uint256(type(GCF.VoteType).max)));
 
     _vars.voteWeightA = uint208(bound(_vars.voteWeightA, 1e4, MAX_VOTES - 1e4 - 1));
-    _vars.voteWeightB =
-      uint208(bound(_vars.voteWeightB, 1e4, MAX_VOTES - _vars.voteWeightA - 1));
+    _vars.voteWeightB = uint208(bound(_vars.voteWeightB, 1e4, MAX_VOTES - _vars.voteWeightA - 1));
 
     uint208 _maxBorrowWeight = _vars.voteWeightA + _vars.voteWeightB;
     _vars.borrowAmountC = uint208(bound(_vars.borrowAmountC, 1, _maxBorrowWeight - 1));
@@ -930,12 +920,12 @@ contract CastVote is FlexVotingClientTest {
 
     // We assert the weight is within a range of 1 because scaled weights are sometimes floored.
     if (_voteTypeA == GCF.VoteType.For) assertApproxEqAbs(_forVotes, _expectedVotingWeightA, 1);
-    if (_voteTypeA == GCF.VoteType.Against) assertApproxEqAbs(_againstVotes, _expectedVotingWeightA, 1);
-    if (_voteTypeA == GCF.VoteType.Abstain) assertApproxEqAbs(_abstainVotes, _expectedVotingWeightA, 1);
-  }
-
-  function test_VotingWeightIsUnaffectedByDepositsAfterProposal() public {
-    testFuzz_VotingWeightIsUnaffectedByDepositsAfterProposal(340282366920938463463374607431768211455, 726, 223);
+    if (_voteTypeA == GCF.VoteType.Against) {
+      assertApproxEqAbs(_againstVotes, _expectedVotingWeightA, 1);
+    }
+    if (_voteTypeA == GCF.VoteType.Abstain) {
+      assertApproxEqAbs(_abstainVotes, _expectedVotingWeightA, 1);
+    }
   }
 
   function testFuzz_VotingWeightIsUnaffectedByDepositsAfterProposal(

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -256,7 +256,7 @@ contract GetPastRawBalance is FlexVotingClientTest {
     vm.assume(_blockNum > 2);
     vm.assume(_blockNum < type(uint48).max);
     _amountA = uint208(bound(_amountA, 1, type(uint128).max));
-    _amountB = uint208(bound(_amountB, 1, type(uint128).max - _amountA));
+    _amountB = uint208(bound(_amountB, 0, type(uint128).max - _amountA));
 
     _mintGovAndDepositIntoFlexClient(_user, _amountA);
     vm.roll(_blockNum);
@@ -402,7 +402,7 @@ contract Deposit is FlexVotingClientTest {
     uint24 _depositDelay
   ) public {
     _amountA = uint208(bound(_amountA, 1, type(uint128).max));
-    _amountB = uint208(bound(_amountB, 1, type(uint128).max));
+    _amountB = uint208(bound(_amountB, 0, type(uint128).max - _amountA));
 
     // Deposit some gov.
     _mintGovAndDepositIntoFlexClient(_user, _amountA);

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -221,11 +221,18 @@ contract GetPastRawBalance is FlexVotingClientTest {
   ) public {
     vm.assume(_depositor != address(flexClient));
     vm.assume(_nonDepositor != address(flexClient));
+    vm.assume(_nonDepositor != _depositor);
     _amount = uint208(bound(_amount, 1, type(uint128).max));
 
+    vm.roll(block.number + 1);
     assertEq(flexClient.getPastRawBalance(_depositor, 0), 0);
-    _mintGovAndDepositIntoFlexClient(_depositor, _amount);
     assertEq(flexClient.getPastRawBalance(_nonDepositor, 0), 0);
+
+    _mintGovAndDepositIntoFlexClient(_depositor, _amount);
+    vm.roll(block.number + 1);
+
+    assertEq(flexClient.getPastRawBalance(_depositor, block.number - 1), _amount);
+    assertEq(flexClient.getPastRawBalance(_nonDepositor, block.number - 1), 0);
   }
 
   function testFuzz_ReturnsCurrentValueForFutureBlocks(

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -102,6 +102,12 @@ contract Deployment is FlexVotingClientTest {
   }
 }
 
+contract Constructor is FlexVotingClientTest {
+  function test_constructor_SetsGovernor() public view {
+    assertEq(address(flexClient.GOVERNOR()), address(governor));
+  }
+}
+
 contract Withdraw is FlexVotingClientTest {
   function testFuzz_UserCanWithdrawGovTokens(address _lender, address _borrower, uint208 _amount)
     public

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -106,6 +106,7 @@ contract Constructor is FlexVotingClientTest {
   function test_SetsGovernor() public view {
     assertEq(address(flexClient.GOVERNOR()), address(governor));
   }
+
   function test_SelfDelegates() public view {
     assertEq(token.delegates(address(flexClient)), address(flexClient));
   }
@@ -147,12 +148,7 @@ contract _RawBalanceOf is FlexVotingClientTest {
     assertEq(flexClient.exposed_rawBalanceOf(_user), 0);
   }
 
-
-  function testFuzz_UnaffectedByBorrow(
-    address _user,
-    uint208 _deposit,
-    uint208 _borrow
-  ) public {
+  function testFuzz_UnaffectedByBorrow(address _user, uint208 _deposit, uint208 _borrow) public {
     _commonUserAssumptions(_user);
     _deposit = uint208(bound(_deposit, 1, type(uint128).max));
     _borrow = uint208(bound(_borrow, 1, _deposit));
@@ -174,8 +170,7 @@ contract _RawBalanceOf is FlexVotingClientTest {
 contract _CastVoteReasonString is FlexVotingClientTest {
   function test_ReturnsDescriptiveString() public {
     assertEq(
-      flexClient.exposed_castVoteReasonString(),
-      "rolled-up vote from governance token holders"
+      flexClient.exposed_castVoteReasonString(), "rolled-up vote from governance token holders"
     );
   }
 }
@@ -446,7 +441,11 @@ contract Deposit is FlexVotingClientTest {
 }
 
 contract ExpressVote is FlexVotingClientTest {
-  function testFuzz_IncrementsInternalAccouting(address _user, uint208 _voteWeight, uint8 _supportType) public {
+  function testFuzz_IncrementsInternalAccouting(
+    address _user,
+    uint208 _voteWeight,
+    uint8 _supportType
+  ) public {
     _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
 
     // Deposit some funds.
@@ -525,7 +524,9 @@ contract ExpressVote is FlexVotingClientTest {
     flexClient.expressVote(_proposalId, uint8(_supportType));
   }
 
-  function testFuzz_RevertOn_DoubleVotes(address _user, uint208 _voteWeight, uint8 _supportType) public {
+  function testFuzz_RevertOn_DoubleVotes(address _user, uint208 _voteWeight, uint8 _supportType)
+    public
+  {
     _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
 
     // Deposit some funds.
@@ -564,11 +565,9 @@ contract ExpressVote is FlexVotingClientTest {
     assertEq(_abstainVotesExpressed, _abstainVotesExpressedInit);
   }
 
-  function testFuzz_RevertOn_UnknownVoteType(
-    address _user,
-    uint208 _voteWeight,
-    uint8 _supportType
-  ) public {
+  function testFuzz_RevertOn_UnknownVoteType(address _user, uint208 _voteWeight, uint8 _supportType)
+    public
+  {
     // Force vote type to be unrecognized.
     vm.assume(_supportType > uint8(GCF.VoteType.Abstain));
 
@@ -590,7 +589,9 @@ contract ExpressVote is FlexVotingClientTest {
 }
 
 contract CastVote is FlexVotingClientTest {
-  function testFuzz_SubmitsVotesToGovernor(address _user, uint208 _voteWeight, uint8 _supportType) public {
+  function testFuzz_SubmitsVotesToGovernor(address _user, uint208 _voteWeight, uint8 _supportType)
+    public
+  {
     _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
 
     // Deposit some funds.
@@ -1020,11 +1021,9 @@ contract CastVote is FlexVotingClientTest {
     assertEq(_abstainVotes, _voteWeightB); // Second user's votes are now in.
   }
 
-  function testFuzz_RevertWhen_NoVotesToCast(
-    address _user,
-    uint208 _voteWeight,
-    uint8 _supportType
-  ) public {
+  function testFuzz_RevertWhen_NoVotesToCast(address _user, uint208 _voteWeight, uint8 _supportType)
+    public
+  {
     _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
 
     // Deposit some funds.
@@ -1081,7 +1080,6 @@ contract CastVote is FlexVotingClientTest {
     );
     flexClient.castVote(_proposalId);
   }
-
 }
 
 contract Borrow is FlexVotingClientTest {

--- a/test/FlexVotingClient.t.sol
+++ b/test/FlexVotingClient.t.sol
@@ -69,15 +69,15 @@ contract FlexVotingClientTest is Test {
     assertEq(uint8(governor.state(proposalId)), uint8(IGovernor.ProposalState.Active));
   }
 
-  function _commonFuzzerAssumptions(address _address, uint208 _voteWeight)
+  function _assumeSafeVoteParams(address _address, uint208 _voteWeight)
     public
     view
     returns (uint208)
   {
-    return _commonFuzzerAssumptions(_address, _voteWeight, uint8(GCF.VoteType.Against));
+    return _assumeSafeVoteParams(_address, _voteWeight, uint8(GCF.VoteType.Against));
   }
 
-  function _commonFuzzerAssumptions(address _address, uint208 _voteWeight, uint8 _supportType)
+  function _assumeSafeVoteParams(address _address, uint208 _voteWeight, uint8 _supportType)
     public
     view
     returns (uint208)
@@ -114,18 +114,18 @@ contract Constructor is FlexVotingClientTest {
 
 // Contract name has a leading underscore for scopelint spec support.
 contract _RawBalanceOf is FlexVotingClientTest {
-  function _commonUserAssumptions(address _user) internal view {
+  function _assumeSafeUser(address _user) internal view {
     vm.assume(_user != address(flexClient));
     vm.assume(_user != address(0));
   }
 
   function testFuzz_ReturnsZeroForNonDepositors(address _user) public view {
-    _commonUserAssumptions(_user);
+    _assumeSafeUser(_user);
     assertEq(flexClient.exposed_rawBalanceOf(_user), 0);
   }
 
   function testFuzz_IncreasesOnDeposit(address _user, uint208 _amount) public {
-    _commonUserAssumptions(_user);
+    _assumeSafeUser(_user);
     _amount = uint208(bound(_amount, 1, type(uint128).max));
 
     // Deposit some gov.
@@ -135,7 +135,7 @@ contract _RawBalanceOf is FlexVotingClientTest {
   }
 
   function testFuzz_DecreasesOnWithdrawal(address _user, uint208 _amount) public {
-    _commonUserAssumptions(_user);
+    _assumeSafeUser(_user);
     _amount = uint208(bound(_amount, 1, type(uint128).max));
 
     // Deposit some gov.
@@ -149,7 +149,7 @@ contract _RawBalanceOf is FlexVotingClientTest {
   }
 
   function testFuzz_UnaffectedByBorrow(address _user, uint208 _deposit, uint208 _borrow) public {
-    _commonUserAssumptions(_user);
+    _assumeSafeUser(_user);
     _deposit = uint208(bound(_deposit, 1, type(uint128).max));
     _borrow = uint208(bound(_borrow, 1, _deposit));
 
@@ -446,7 +446,7 @@ contract ExpressVote is FlexVotingClientTest {
     uint208 _voteWeight,
     uint8 _supportType
   ) public {
-    _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
+    _voteWeight = _assumeSafeVoteParams(_user, _voteWeight, _supportType);
 
     // Deposit some funds.
     _mintGovAndDepositIntoFlexClient(_user, _voteWeight);
@@ -476,7 +476,7 @@ contract ExpressVote is FlexVotingClientTest {
     uint208 _voteWeight,
     uint8 _supportType
   ) public {
-    _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
+    _voteWeight = _assumeSafeVoteParams(_user, _voteWeight, _supportType);
 
     // Create the proposal *before* the user deposits anything.
     uint256 _proposalId = _createAndSubmitProposal();
@@ -496,7 +496,7 @@ contract ExpressVote is FlexVotingClientTest {
     uint208 _voteWeight,
     uint8 _supportType
   ) public {
-    _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
+    _voteWeight = _assumeSafeVoteParams(_user, _voteWeight, _supportType);
 
     // Mint gov but do not deposit.
     _mintGovAndApproveFlexClient(_user, _voteWeight);
@@ -527,7 +527,7 @@ contract ExpressVote is FlexVotingClientTest {
   function testFuzz_RevertOn_DoubleVotes(address _user, uint208 _voteWeight, uint8 _supportType)
     public
   {
-    _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
+    _voteWeight = _assumeSafeVoteParams(_user, _voteWeight, _supportType);
 
     // Deposit some funds.
     _mintGovAndDepositIntoFlexClient(_user, _voteWeight);
@@ -592,7 +592,7 @@ contract CastVote is FlexVotingClientTest {
   function testFuzz_SubmitsVotesToGovernor(address _user, uint208 _voteWeight, uint8 _supportType)
     public
   {
-    _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
+    _voteWeight = _assumeSafeVoteParams(_user, _voteWeight, _supportType);
 
     // Deposit some funds.
     _mintGovAndDepositIntoFlexClient(_user, _voteWeight);
@@ -632,8 +632,8 @@ contract CastVote is FlexVotingClientTest {
     uint208 _voteWeightB,
     uint8 _supportType
   ) public {
-    _voteWeightA = _commonFuzzerAssumptions(_user, _voteWeightA, _supportType);
-    _voteWeightB = _commonFuzzerAssumptions(_user, _voteWeightB, _supportType);
+    _voteWeightA = _assumeSafeVoteParams(_user, _voteWeightA, _supportType);
+    _voteWeightB = _assumeSafeVoteParams(_user, _voteWeightB, _supportType);
 
     // Deposit some funds.
     _mintGovAndDepositIntoFlexClient(_user, _voteWeightA);
@@ -843,9 +843,9 @@ contract CastVote is FlexVotingClientTest {
       address(0xbabe), // userB
       address(0xf005ba11) // userC
     ];
-    _voteWeightA = _commonFuzzerAssumptions(_users[0], _voteWeightA, _supportTypeA);
-    _voteWeightB = _commonFuzzerAssumptions(_users[1], _voteWeightB);
-    _borrowAmount = _commonFuzzerAssumptions(_users[2], _borrowAmount);
+    _voteWeightA = _assumeSafeVoteParams(_users[0], _voteWeightA, _supportTypeA);
+    _voteWeightB = _assumeSafeVoteParams(_users[1], _voteWeightB);
+    _borrowAmount = _assumeSafeVoteParams(_users[2], _borrowAmount);
 
     _voteWeightA = uint208(bound(_voteWeightA, 0, type(uint128).max));
     _voteWeightB = uint208(bound(_voteWeightB, 0, type(uint128).max - _voteWeightA));
@@ -924,8 +924,8 @@ contract CastVote is FlexVotingClientTest {
       address(0xbabe), // userB
       address(0xf005ba11) // userC
     ];
-    _voteWeightA = _commonFuzzerAssumptions(_users[0], _voteWeightA, _supportTypeA);
-    _voteWeightB = _commonFuzzerAssumptions(_users[1], _voteWeightB);
+    _voteWeightA = _assumeSafeVoteParams(_users[0], _voteWeightA, _supportTypeA);
+    _voteWeightB = _assumeSafeVoteParams(_users[1], _voteWeightB);
 
     vm.assume(_voteWeightA + _voteWeightB < type(uint128).max);
 
@@ -1024,7 +1024,7 @@ contract CastVote is FlexVotingClientTest {
   function testFuzz_RevertWhen_NoVotesToCast(address _user, uint208 _voteWeight, uint8 _supportType)
     public
   {
-    _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
+    _voteWeight = _assumeSafeVoteParams(_user, _voteWeight, _supportType);
 
     // Deposit some funds.
     _mintGovAndDepositIntoFlexClient(_user, _voteWeight);
@@ -1053,7 +1053,7 @@ contract CastVote is FlexVotingClientTest {
     uint208 _voteWeight,
     uint8 _supportType
   ) public {
-    _voteWeight = _commonFuzzerAssumptions(_user, _voteWeight, _supportType);
+    _voteWeight = _assumeSafeVoteParams(_user, _voteWeight, _supportType);
 
     // Deposit some funds.
     _mintGovAndDepositIntoFlexClient(_user, _voteWeight);
@@ -1090,8 +1090,8 @@ contract Borrow is FlexVotingClientTest {
     uint208 _borrowAmount
   ) public {
     vm.assume(_borrower != address(0));
-    _depositAmount = _commonFuzzerAssumptions(_depositer, _depositAmount);
-    _borrowAmount = _commonFuzzerAssumptions(_borrower, _borrowAmount);
+    _depositAmount = _assumeSafeVoteParams(_depositer, _depositAmount);
+    _borrowAmount = _assumeSafeVoteParams(_borrower, _borrowAmount);
     vm.assume(_depositAmount > _borrowAmount);
 
     // Deposit some funds.

--- a/test/MockFlexVotingClient.sol
+++ b/test/MockFlexVotingClient.sol
@@ -36,6 +36,18 @@ contract MockFlexVotingClient is FlexVotingClient {
     return _castVoteReasonString();
   }
 
+  function exposed_selfDelegate() external {
+    return _selfDelegate();
+  }
+
+  function exposed_setDeposits(address _user, uint208 _amount) external {
+    deposits[_user] = _amount;
+  }
+
+  function exposed_checkpointRawBalanceOf(address _user) external {
+    return _checkpointRawBalanceOf(_user);
+  }
+
   /// @notice Allow a holder of the governance token to deposit it into the pool.
   /// @param _amount The amount to be deposited.
   function deposit(uint208 _amount) public {

--- a/test/MockFlexVotingClient.sol
+++ b/test/MockFlexVotingClient.sol
@@ -28,6 +28,14 @@ contract MockFlexVotingClient is FlexVotingClient {
     return deposits[_user];
   }
 
+  function exposed_rawBalanceOf(address _user) external view returns (uint208) {
+    return _rawBalanceOf(_user);
+  }
+
+  function exposed_castVoteReasonString() external returns (string memory) {
+    return _castVoteReasonString();
+  }
+
   /// @notice Allow a holder of the governance token to deposit it into the pool.
   /// @param _amount The amount to be deposited.
   function deposit(uint208 _amount) public {


### PR DESCRIPTION
Fixes #69

This PR restructures the FlexClient tests to accord with `scopelint spec`. Some tests were renamed. Other tests were added. The resulting spec is:

```
Contract Specification: FlexVotingClient
├── constructor
│   ├──  Sets Governor
│   └──  Self Delegates
├── _rawBalanceOf
│   ├──  Returns Zero For Non Depositors
│   ├──  Increases On Deposit
│   ├──  Decreases On Withdrawal
│   └──  Unaffected By Borrow
├── _castVoteReasonString
│   └──  Returns Descriptive String
├── _selfDelegate
│   └──  Sets Client As The Delegate
├── expressVote
│   ├──  Increments Internal Accouting
│   ├──  Revert When: Depositing After Proposal
│   ├──  Revert When: No Client Weight But Token Weight
│   ├──  Revert On: Double Votes
│   └──  Revert On: Unknown Vote Type
├── castVote
│   ├──  Submits Votes To Governor
│   ├──  Weight Is Snapshot Dependent
│   ├──  Tracks Multiple Users Votes
│   ├──  Scales Vote Weight Based On Pool Balance
│   ├──  Abandons Unexpressed Voting Weight
│   ├──  Voting Weight Is Unaffected By Deposits After Proposal
│   ├──  Can Call Multiple Times For The Same Proposal
│   ├──  Revert When: No Votes To Cast
│   └──  Revert When: After Voting Period
├── _checkpointRawBalanceOf
│   └──  Stores The Raw Balance With The Block Number
├── getPastRawBalance
│   ├──  Returns Zero For Users Without Deposits
│   ├──  Returns Current Value For Future Blocks
│   └──  Returns User Balance At A Given Block
└── getPastTotalBalance
    ├──  Returns Zero Without Deposits
    ├──  Returns Current Value For Future Blocks
    ├──  Sums All User Deposits
    └──  Returns Total Deposits At A Given Block
```