### PR TITLE
Switch back to nightly build of foundry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-e649e62f125244a3ef116be25dfdc81a2afbaf2a
+          version: nightly
 
       - name: Run tests
         run: forge test


### PR DESCRIPTION
Remappings were causing the issue that broke CI a few days ago. Figured it out by making a minimal repro [here](https://github.com/davidlaprade/foundry-ci-failure-repro/actions/workflows/ci.yml)

This was caused by a bug in foundry, reported here https://github.com/foundry-rs/foundry/issues/9375 and fixed here https://github.com/foundry-rs/foundry/pull/9379