### PR TITLE
Mark inline assembly as memory-safe

### DIFF
--- a/src/GovernorCountingFractional.sol
+++ b/src/GovernorCountingFractional.sol
@@ -261,6 +261,7 @@ abstract contract GovernorCountingFractional is Governor {
             uint128 abstainVotes
         )
     {
+        /// @solidity memory-safe-assembly
         assembly {
             againstVotes := shr(128, mload(add(voteData, 0x20)))
             forVotes := and(_MASK_HALF_WORD_RIGHT, mload(add(voteData, 0x20)))


### PR DESCRIPTION
Fixes #52

The `GovernorCountingFractional` contract will be removed in a future release when we bump OZ to v5.1. But for the sake of users that can't upgrade to OZ v5.1, we're marking the use of assembly in that contract as memory-safe.

Per the [solidity docs](https://docs.soliditylang.org/en/latest/assembly.html#memory-safety):

<img width="700" alt="image" src="https://github.com/user-attachments/assets/5b8cf066-b205-47ed-b832-b19968e015c6" />

The only assembly we have is here:

```solidity
    function _decodePackedVotes(bytes memory voteData)
        internal
        pure
        returns (
            uint128 againstVotes,
            uint128 forVotes,
            uint128 abstainVotes
        )
    {
        assembly {
            againstVotes := shr(128, mload(add(voteData, 0x20)))
            forVotes := and(_MASK_HALF_WORD_RIGHT, mload(add(voteData, 0x20)))
            abstainVotes := shr(128, mload(add(voteData, 0x40)))
        }
    }
 ```


This assembly doesn't write to any memory variables. Nor does it allocate any. Instead, it assigns to return variables which solidity has already assigned to stack slots. It only reads from the `voteData` memory param, and does so within its already-allocated bounds (the caller would have reverted if `voteData.length != 48`). It doesn't modify any scratch space or the free memory pointer.